### PR TITLE
[Feat] webserv config 구현을 위한 Server, Location 클래스 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@
 *.exe
 *.out
 *.app
+
+.vscode/

--- a/Config.hpp
+++ b/Config.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#ifndef __CONFIG_HPP__
+#define __CONFIG_HPP__
+
+// 서버가 사용하는 설정들을 정의해 둔 static 클래스
+class Config {
+ public:
+  // 서버가 처리할 수 있는 최소 body 크기
+  static const int MIN_LIMIT_BODY_SIZE = 0;
+  // 서버가 처리할 수 있는 최대 body 크기
+  static const int MAX_LIMIT_BODY_SIZE = 100000000;
+
+ private:
+  Config(void);
+  Config(Config const& config);
+  ~Config(void);
+  Config& operator=(Config const& config);
+};
+
+#endif

--- a/Config.hpp
+++ b/Config.hpp
@@ -1,4 +1,3 @@
-#pragma once
 #ifndef __CONFIG_HPP__
 #define __CONFIG_HPP__
 

--- a/EMethod.h
+++ b/EMethod.h
@@ -1,6 +1,0 @@
-#ifndef __METHOD_HPP__
-#define __METHOD_HPP__
-
-enum EMethod { GET, POST, DELETE };
-
-#endif

--- a/EMethod.h
+++ b/EMethod.h
@@ -1,0 +1,6 @@
+#ifndef __METHOD_HPP__
+#define __METHOD_HPP__
+
+enum EMethod { GET, POST, DELETE };
+
+#endif

--- a/Enum.hpp
+++ b/Enum.hpp
@@ -1,0 +1,6 @@
+#ifndef __ENUM_HPP__
+#define __ENUM_HPP__
+
+enum EHttpMethod { GET, POST, DELETE };
+
+#endif

--- a/Location.cpp
+++ b/Location.cpp
@@ -1,0 +1,139 @@
+#include "Location.hpp"
+
+#include <stdexcept>
+
+// Constructor & Destructor
+
+Location::Location(const std::string& uri, const std::string& rootPath,
+                   const std::string& indexFile)
+    : _uri(uri),
+      _rootPath(rootPath),
+      _indexFile(indexFile),
+      _maxBodySize(DEFAULT_MAX_BODY_SIZE),
+      _autoIndex(false),
+      _hasAllowMethodField(false),
+      _hasRedirectField(false) {}
+
+Location::Location(Location const& location) { *this = location; }
+
+Location::~Location(void) {}
+
+// Operator Overloading
+
+Location& Location::operator=(Location const& location) {
+  if (this != &location) {
+    this->_uri = location._uri;
+    this->_rootPath = location._rootPath;
+    this->_indexFile = location._indexFile;
+
+    this->_maxBodySize = location._maxBodySize;
+    this->_errorPages = location._errorPages;
+    this->_allowMethods = location._allowMethods;
+    this->_autoIndex = location._autoIndex;
+    this->_redirectUri = location._redirectUri;
+  }
+  return *this;
+}
+
+// Public Method - setter
+
+// - Location 블럭의 max body size 설정
+// - 호출하지 않을 시 기본값(DEFAULT_MAX_BODY_SIZE) 적용
+// - size 범위 초과시 예외 발생
+void Location::setMaxBodySize(int size) {
+  if (size < MIN_LIMIT_BODY_SIZE or size > MAX_LIMIT_BODY_SIZE) {
+    throw std::runtime_error("Location: setMaxBodySize() - size range error");
+  }
+  _maxBodySize = size;
+}
+
+// - Location 블럭에 특정 상태코드에 대한 error page 경로 추가
+// - 이미 있는 상태코드를 다시 추가할 경우 예외 발생
+void Location::addErrorPage(int statusCode, const std::string& path) {
+  if (_errorPages.find(statusCode) != _errorPages.end()) {
+    throw std::runtime_error(
+        "Location: addErrorPage() - duplicate status number");
+  }
+  _errorPages[statusCode] = path;
+}
+
+// - Location 블럭에 허용할 메서드 추가
+// - 호출하지 않을 시 모든 메서드 허용
+// - 이미 있는 메서드를 다시 추가할 경우 예외 발생
+void Location::addAllowMethod(EMethod method) {
+  // 한번이라도 이 메서드가 호출된 경우 차단된 메서드가 있다고 판단
+  _hasAllowMethodField = true;
+  if (_allowMethods.find(method) != _allowMethods.end()) {
+    throw std::runtime_error("Location: addAllowMethod() - duplicate method");
+  }
+  _allowMethods.insert(method);
+}
+
+// - Location 블럭의 autoindex 설정
+// - 호출하지 않을 시 기본값(false) 적용
+void Location::setAutoIndex(bool setting) { _autoIndex = setting; }
+
+// - Location 블럭에 redirect할 uri 설정
+// - 호출하지 않을 시 redirect 블럭이 아님
+// - redirect uri 설정 시 해당 location 블럭은 무조건 redirect 됨
+void Location::setRedirectUri(const std::string& path) {
+  // 한번이라도 이 메서드가 호출된 경우 redirect 블럭으로 판단
+  _hasRedirectField = true;
+  _redirectUri = path;
+}
+
+// Public Method - getter
+
+const std::string& Location::getUri(void) const { return _uri; }
+
+const std::string& Location::getRootPath(void) const { return _rootPath; }
+
+const std::string& Location::getIndexFile(void) const { return _indexFile; }
+
+int Location::getMaxBodySize(void) const { return _maxBodySize; }
+
+// - 해당 상태코드에 대한 에러 페이지 경로가 존재하는지 여부 반환
+bool Location::hasErrorPage(int statusCode) const {
+  if (_errorPages.find(statusCode) == _errorPages.end()) {
+    return false;
+  }
+  return true;
+}
+
+// - 해당 상태코드에 대한 에러 페이지 경로 반환
+// - 에러 페이지 경로가 존재하지 않을 경우 예외 발생
+const std::string& Location::getErrorPagePath(int statusCode) const {
+  if (_errorPages.find(statusCode) == _errorPages.end()) {
+    throw std::runtime_error(
+        "Location: getErrorPagePath() - no path corresponds to the status "
+        "code.");
+  }
+  std::map<int, std::string>::const_iterator it = _errorPages.find(statusCode);
+  return it->second;
+}
+
+// - 해당 메서드가 허용되는지 여부 반환
+bool Location::isAllowMethod(EMethod method) const {
+  if (_hasAllowMethodField == false) {
+    return true;
+  }
+  if (_allowMethods.find(method) == _allowMethods.end()) {
+    return false;
+  }
+  return true;
+}
+
+bool Location::isAutoIndex(void) const { return _autoIndex; }
+
+// - 해당 블럭이 redirect 필드를 가지고 있는지 여부 반환
+bool Location::isRedirectBlock(void) const { return _hasRedirectField; }
+
+// - 해당 블럭의 redirect uri 반환
+// - 해당 블릭이 redirect 블럭이 아닌 경우 예외 발생
+const std::string& Location::getRedirectUri(void) const {
+  if (_hasRedirectField == false) {
+    throw std::runtime_error(
+        "Location: getRedirectUri() - doesn't have a uri.");
+  }
+  return _redirectUri;
+}

--- a/Location.cpp
+++ b/Location.cpp
@@ -60,7 +60,7 @@ void Location::addErrorPage(int statusCode, const std::string& path) {
 // - Location 블럭에 허용할 메서드 추가
 // - 호출하지 않을 시 모든 메서드 허용
 // - 이미 있는 메서드를 다시 추가할 경우 예외 발생
-void Location::addAllowMethod(EMethod method) {
+void Location::addAllowMethod(EHttpMethod method) {
   // 한번이라도 이 메서드가 호출된 경우 차단된 메서드가 있다고 판단
   _hasAllowMethodField = true;
   if (_allowMethods.find(method) != _allowMethods.end()) {
@@ -113,7 +113,7 @@ const std::string& Location::getErrorPagePath(int statusCode) const {
 }
 
 // - 해당 메서드가 허용되는지 여부 반환
-bool Location::isAllowMethod(EMethod method) const {
+bool Location::isAllowMethod(EHttpMethod method) const {
   if (_hasAllowMethodField == false) {
     return true;
   }

--- a/Location.cpp
+++ b/Location.cpp
@@ -41,7 +41,8 @@ Location& Location::operator=(Location const& location) {
 // - 호출하지 않을 시 기본값(DEFAULT_MAX_BODY_SIZE) 적용
 // - size 범위 초과시 예외 발생
 void Location::setMaxBodySize(int size) {
-  if (size < MIN_LIMIT_BODY_SIZE or size > MAX_LIMIT_BODY_SIZE) {
+  if (size < Config::MIN_LIMIT_BODY_SIZE or
+      size > Config::MAX_LIMIT_BODY_SIZE) {
     throw std::runtime_error("Location: setMaxBodySize() - size range error");
   }
   _maxBodySize = size;

--- a/Location.hpp
+++ b/Location.hpp
@@ -1,0 +1,62 @@
+#ifndef __LOCATION_HPP__
+#define __LOCATION_HPP__
+
+#include <map>
+#include <set>
+#include <string>
+
+#include "EMethod.h"
+
+// config 파일의 Location 블럭
+// - location 블럭의 정보를 저장한다.
+class Location {
+ private:
+  std::string _uri;
+  std::string _rootPath;
+  std::string _indexFile;
+
+  int _maxBodySize;
+  std::map<int, std::string> _errorPages;
+  std::set<EMethod> _allowMethods;
+  bool _autoIndex;
+  std::string _redirectUri;
+
+ public:
+  Location(const std::string& uri, const std::string& rootPath,
+           const std::string& indexFile);
+  Location(Location const& location);
+  ~Location(void);
+
+  Location& operator=(Location const& location);
+
+  // setter
+  void setMaxBodySize(int size);
+  void addErrorPage(int statusNumber, const std::string& path);
+  void addAllowMethod(EMethod method);
+  void setAutoIndex(bool setting);
+  void setRedirectUri(const std::string& path);
+
+  // getter
+  const std::string& getUri(void) const;
+  const std::string& getRootPath(void) const;
+  const std::string& getIndexFile(void) const;
+  int getMaxBodySize(void) const;
+  bool hasErrorPage(int statusCode) const;
+  const std::string& getErrorPagePath(int statusCode) const;
+  bool isAllowMethod(EMethod method) const;
+  bool isAutoIndex(void) const;
+  bool isRedirectBlock(void) const;
+  const std::string& getRedirectUri(void) const;
+
+ private:
+  static const int DEFAULT_MAX_BODY_SIZE = 6000;
+  static const int MIN_LIMIT_BODY_SIZE = 0;
+  static const int MAX_LIMIT_BODY_SIZE = 100000000;
+
+  bool _hasAllowMethodField;
+  bool _hasRedirectField;
+
+  Location(void);
+};
+
+#endif

--- a/Location.hpp
+++ b/Location.hpp
@@ -5,7 +5,7 @@
 #include <set>
 #include <string>
 
-#include "EMethod.h"
+#include "Enum.hpp"
 
 // config 파일의 Location 블럭
 // - location 블럭의 정보를 저장한다.
@@ -17,7 +17,7 @@ class Location {
 
   int _maxBodySize;
   std::map<int, std::string> _errorPages;
-  std::set<EMethod> _allowMethods;
+  std::set<EHttpMethod> _allowMethods;
   bool _autoIndex;
   std::string _redirectUri;
 
@@ -32,7 +32,7 @@ class Location {
   // setter
   void setMaxBodySize(int size);
   void addErrorPage(int statusNumber, const std::string& path);
-  void addAllowMethod(EMethod method);
+  void addAllowMethod(EHttpMethod method);
   void setAutoIndex(bool setting);
   void setRedirectUri(const std::string& path);
 
@@ -43,7 +43,7 @@ class Location {
   int getMaxBodySize(void) const;
   bool hasErrorPage(int statusCode) const;
   const std::string& getErrorPagePath(int statusCode) const;
-  bool isAllowMethod(EMethod method) const;
+  bool isAllowMethod(EHttpMethod method) const;
   bool isAutoIndex(void) const;
   bool isRedirectBlock(void) const;
   const std::string& getRedirectUri(void) const;

--- a/Location.hpp
+++ b/Location.hpp
@@ -5,6 +5,7 @@
 #include <set>
 #include <string>
 
+#include "Config.hpp"
 #include "Enum.hpp"
 
 // config 파일의 Location 블럭
@@ -50,8 +51,6 @@ class Location {
 
  private:
   static const int DEFAULT_MAX_BODY_SIZE = 6000;
-  static const int MIN_LIMIT_BODY_SIZE = 0;
-  static const int MAX_LIMIT_BODY_SIZE = 100000000;
 
   bool _hasAllowMethodField;
   bool _hasRedirectField;

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+NAME		= config_test
+CXX			= c++
+CXXFLAGS	= -Wall -Werror -Wextra -std=c++98
+
+SRCS		= Server.cpp \
+					Location.cpp \
+					main.cpp
+
+OBJS		= $(SRCS:%.cpp=%.o)
+
+all	:		$(NAME)
+
+$(NAME) : 	$(OBJS)
+			$(CXX) $(CXXFLAGS) -o $(NAME) $(OBJS)
+
+%.o	: 		%.cpp
+			$(CXX) $(CXXFLAGS) -c $^ -I./ -o $@
+
+clean	:
+			rm -f $(OBJS)
+
+fclean	:
+			make clean
+			rm -f $(NAME)
+
+re	:
+			make fclean
+			make all
+
+.PHONY	:	all clean fclean re

--- a/Server.cpp
+++ b/Server.cpp
@@ -53,6 +53,9 @@ void Server::addLocationBlock(const Location& locationBlock) {
 
 // Public Method - method
 
+// - uri와 prefix가 매칭되는 Location 객체를 반환
+// - uri가 /인 Location 객체는 반드시 존재한다고 가정
+// - uri 매칭에 실패하는 경우는 없음
 const Location& Server::getMatchedLocationBlock(const std::string& uri) {
   std::string bestMatch;
   size_t longestMatchLength = 0;
@@ -70,4 +73,13 @@ const Location& Server::getMatchedLocationBlock(const std::string& uri) {
 
   it = _locationBlocks.find(bestMatch);
   return it->second;
+}
+
+// - Server 블록에 uri가 /인 Location 블록이 존재하는지 여부 반환
+// - Server 블록에는 uri가 /인 Location 블록이 반드시 존재해야함
+bool Server::hasDefaultLocationBlock(void) {
+  if (_locationBlocks.find("/") == _locationBlocks.end()) {
+    return false;
+  }
+  return true;
 }

--- a/Server.cpp
+++ b/Server.cpp
@@ -60,7 +60,7 @@ const Location& Server::getMatchedLocationBlock(const std::string& uri) {
   LocationMap::const_iterator it = _locationBlocks.begin();
   while (it != _locationBlocks.end()) {
     const std::string& key = it->first;
-    if (uri.compare(0, key.length(), key) == 0 &&
+    if (uri.compare(0, key.length(), key) == 0 and
         key.length() > longestMatchLength) {
       bestMatch = it->first;
       longestMatchLength = key.length();

--- a/Server.cpp
+++ b/Server.cpp
@@ -1,0 +1,73 @@
+#include "Server.hpp"
+
+#include <stdexcept>
+
+// Constructor & Destructor
+
+Server::Server(std::string hostIp, int port)
+    : _hostIp(hostIp),
+      _port(port){
+          // TODO: invalid한 포트 번호 검증 추가
+      };
+
+Server::Server(Server const& server) { *this = server; }
+
+Server::~Server(void) {}
+
+// Operator Overloading
+
+Server& Server::operator=(Server const& server) {
+  if (this != &server) {
+    this->_hostIp = server._hostIp;
+    this->_port = server._port;
+
+    this->_serverNames = server._serverNames;
+    this->_locationBlocks = server._locationBlocks;
+  }
+  return *this;
+}
+
+// Public Method - setter
+
+// - server name을 추가
+// - 이미 있는 server name이 들어올 경우 예외 발생
+void Server::addServerName(const std::string& serverName) {
+  if (_serverNames.find(serverName) != _serverNames.end()) {
+    throw std::runtime_error("Server: addServerName() - duplicate server name");
+  }
+  _serverNames.insert(serverName);
+}
+
+// - Server 블럭에 포함된 location 블럭 추가
+// - 같은 uri를 가진 location 블럭이 들어온 경우 예외 발생
+void Server::addLocationBlock(const Location& locationBlock) {
+  std::string uri = locationBlock.getUri();
+
+  if (_locationBlocks.find(uri) != _locationBlocks.end()) {
+    throw std::runtime_error(
+        "Server: addLocationBlock() - duplicate location block uri");
+  }
+
+  _locationBlocks.insert(std::make_pair(uri, locationBlock));
+}
+
+// Public Method - method
+
+const Location& Server::getMatchedLocationBlock(const std::string& uri) {
+  std::string bestMatch;
+  size_t longestMatchLength = 0;
+
+  LocationMap::const_iterator it = _locationBlocks.begin();
+  while (it != _locationBlocks.end()) {
+    const std::string& key = it->first;
+    if (uri.compare(0, key.length(), key) == 0 &&
+        key.length() > longestMatchLength) {
+      bestMatch = it->first;
+      longestMatchLength = key.length();
+    }
+    ++it;
+  }
+
+  it = _locationBlocks.find(bestMatch);
+  return it->second;
+}

--- a/Server.hpp
+++ b/Server.hpp
@@ -1,9 +1,9 @@
 #ifndef __SERVER_HPP__
 #define __SERVER_HPP__
 
+#include <map>
 #include <set>
 #include <string>
-#include <map>
 
 #include "Location.hpp"
 
@@ -30,10 +30,11 @@ class Server {
 
   // method
   const Location& getMatchedLocationBlock(const std::string& uri);
+  bool hasDefaultLocationBlock(void);
 
  private:
   typedef std::map<std::string, Location> LocationMap;
-  
+
   Server(void);
 };
 

--- a/Server.hpp
+++ b/Server.hpp
@@ -1,0 +1,40 @@
+#ifndef __SERVER_HPP__
+#define __SERVER_HPP__
+
+#include <set>
+#include <string>
+#include <map>
+
+#include "Location.hpp"
+
+// config 파일의 Server 블럭
+// - request에 맞는 location 블럭을 리턴한다.
+class Server {
+ private:
+  std::string _hostIp;
+  int _port;
+
+  std::set<std::string> _serverNames;
+  std::map<std::string, Location> _locationBlocks;
+
+ public:
+  Server(std::string hostIp, int port);
+  Server(Server const& server);
+  ~Server(void);
+
+  Server& operator=(Server const& server);
+
+  // setter
+  void addServerName(const std::string& serverName);
+  void addLocationBlock(const Location& locationBlock);
+
+  // method
+  const Location& getMatchedLocationBlock(const std::string& uri);
+
+ private:
+  typedef std::map<std::string, Location> LocationMap;
+  
+  Server(void);
+};
+
+#endif

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,83 @@
+#include <iostream>
+
+#include "Location.hpp"
+#include "Server.hpp"
+
+int main(void) {
+  /**
+   *  location / {
+        root /var/www/html;
+        index index.html;
+
+        limit_except GET POST;
+        client_max_body_size 10000000;
+        autoindex off;
+        error_page 404 /404.html;
+      }
+  */
+
+  Location location1("/", "/var/www/html", "index.html");
+
+  location1.addAllowMethod(GET);
+  location1.addAllowMethod(POST);
+  location1.setMaxBodySize(10000000);
+  location1.setAutoIndex(false);
+  location1.addErrorPage(404, "/404.html");
+
+  /**
+   *  location /images/ {
+        root /var/www/images;
+        index index.html;
+
+        limit_except GET;
+        autoindex on;
+      }
+  */
+
+  Location location2("/images/", "/var/www/images", "index.html");
+
+  location2.addAllowMethod(GET);
+  location2.setAutoIndex(true);
+
+  /**
+   *  location /api/ {
+        root /var/www/api;
+        index index.php;
+
+        limit_except GET POST DELETE;
+        client_max_body_size 15000000;
+        autoindex off;
+        error_page 500 /500.html;
+        error_page 403 /403.html;
+      }
+  */
+
+  Location location3("/api/", "/var/www/api", "index.php");
+
+  location3.addAllowMethod(GET);
+  location3.addAllowMethod(POST);
+  location3.addAllowMethod(DELETE);
+  location3.setMaxBodySize(15000000);
+  location3.setAutoIndex(false);
+  location3.addErrorPage(500, "/500.html");
+  location3.addErrorPage(403, "/403.html");
+
+  /**
+   * server {
+      listen 127.0.0.1:8080;
+      server_name example.com www.example.com;
+    }
+  */
+
+  Server server("127.0.0.1", 8080);
+
+  server.addLocationBlock(location1);
+  server.addLocationBlock(location2);
+  server.addLocationBlock(location3);
+
+  Location res = server.getMatchedLocationBlock("/api/");
+
+  std::cout << res.getRootPath() << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
![image](https://github.com/wonyangs/webserv/assets/43935708/2cb7d7c0-452d-4f20-84ff-75a18b7b130a)

- 사전 회의를 통해 결정된 config 구조를 담을 수 있는 클래스 구현

### Server

- config의 Server 블록 정보 관리
- Server 블록 안에 있는 Location 블록에 대한 객체 관리
- 서버로 들어온 path에 대해 매칭되는 Location 객체 반환

### Location

- config의 Location 블록 정보 관리

### main에 사용된 예제 config 내용

```text
server {
    listen 127.0.0.1:8080;

    server_name example.com www.example.com;

    location / {
        root /var/www/html;
        index index.html;

        limit_except GET POST;
        client_max_body_size 10000000;
        autoindex off;
        error_page 404 /404.html;
    }

    location /images/ {
        root /var/www/images;
        index index.html;

        limit_except GET;
        autoindex on;
    }

    location /api/ {
        root /var/www/api;
        index index.php;

        limit_except GET POST DELETE;
        client_max_body_size 15000000;
        autoindex off;
        error_page 500 /500.html;
        error_page 403 /403.html;
    }
}
```

### issue

close #2 