### PR TITLE
[Refactor] Server, Location 클래스 예외 메시지 수정

### DIFF
--- a/Location.cpp
+++ b/Location.cpp
@@ -43,7 +43,7 @@ Location& Location::operator=(Location const& location) {
 void Location::setMaxBodySize(int size) {
   if (size < Config::MIN_LIMIT_BODY_SIZE or
       size > Config::MAX_LIMIT_BODY_SIZE) {
-    throw std::runtime_error("Location: setMaxBodySize() - size range error");
+    throw std::runtime_error("[1100] Location: setMaxBodySize - range error");
   }
   _maxBodySize = size;
 }
@@ -53,7 +53,7 @@ void Location::setMaxBodySize(int size) {
 void Location::addErrorPage(int statusCode, const std::string& path) {
   if (_errorPages.find(statusCode) != _errorPages.end()) {
     throw std::runtime_error(
-        "Location: addErrorPage() - duplicate status number");
+        "[1101] Location: addErrorPage - duplicate status code");
   }
   _errorPages[statusCode] = path;
 }
@@ -65,7 +65,8 @@ void Location::addAllowMethod(EHttpMethod method) {
   // 한번이라도 이 메서드가 호출된 경우 차단된 메서드가 있다고 판단
   _hasAllowMethodField = true;
   if (_allowMethods.find(method) != _allowMethods.end()) {
-    throw std::runtime_error("Location: addAllowMethod() - duplicate method");
+    throw std::runtime_error(
+        "[1102] Location: addAllowMethod - duplicate method");
   }
   _allowMethods.insert(method);
 }
@@ -106,8 +107,7 @@ bool Location::hasErrorPage(int statusCode) const {
 const std::string& Location::getErrorPagePath(int statusCode) const {
   if (_errorPages.find(statusCode) == _errorPages.end()) {
     throw std::runtime_error(
-        "Location: getErrorPagePath() - no path corresponds to the status "
-        "code.");
+        "[1103] Location: getErrorPagePath - no path to status code");
   }
   std::map<int, std::string>::const_iterator it = _errorPages.find(statusCode);
   return it->second;
@@ -134,7 +134,7 @@ bool Location::isRedirectBlock(void) const { return _hasRedirectField; }
 const std::string& Location::getRedirectUri(void) const {
   if (_hasRedirectField == false) {
     throw std::runtime_error(
-        "Location: getRedirectUri() - doesn't have a uri.");
+        "[1104] Location: getRedirectUri - doesn't have a uri");
   }
   return _redirectUri;
 }

--- a/Server.cpp
+++ b/Server.cpp
@@ -33,7 +33,7 @@ Server& Server::operator=(Server const& server) {
 // - 이미 있는 server name이 들어올 경우 예외 발생
 void Server::addServerName(const std::string& serverName) {
   if (_serverNames.find(serverName) != _serverNames.end()) {
-    throw std::runtime_error("Server: addServerName() - duplicate server name");
+    throw std::runtime_error("[1000] Server: addServerName - duplicate server_name");
   }
   _serverNames.insert(serverName);
 }
@@ -45,7 +45,7 @@ void Server::addLocationBlock(const Location& locationBlock) {
 
   if (_locationBlocks.find(uri) != _locationBlocks.end()) {
     throw std::runtime_error(
-        "Server: addLocationBlock() - duplicate location block uri");
+        "[1001] Server: addLocationBlock - duplicate uri");
   }
 
   _locationBlocks.insert(std::make_pair(uri, locationBlock));


### PR DESCRIPTION
<img width="875" alt="image" src="https://github.com/wonyangs/webserv/assets/43935708/fd87ae9a-b560-4c30-a382-c9893c590593">

- 회의에서 결정된 에러 코드 형식에 맞춰 예외 메시지 수정
  - 기존에 이미 작업된 Server, Location 클래스에 대해 적용
- 에러 코드 명세 페이지에 기존 코드에 있던 예외 추가

### 예외 메시지 형식
- 형식: `[에러코드] {클래스명}: {함수명} - {예외 메시지}`
    - [1000] Server: addServerName - duplicate server name
    - 클래스명은 대문자로 시작, 함수명과 예외 메시지는 소문자로 시작
    - 예외 메시지에 마침표 붙이지 않기
 
### issue
close: #3 