### PR TITLE
[Feat] RequestParser 기본 버전 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,17 @@ CXX			= c++
 CXXFLAGS	= -Wall -Werror -Wextra -std=c++98
 
 SRCS		= config/Server.cpp \
-					config/Location.cpp \
-					utils/StatusException.cpp \
-					core/Kqueue.cpp \
-					core/Event.cpp \
-					core/Socket.cpp \
-					core/Connection.cpp \
-					core/ServerManager.cpp \
-					core/EventLoop.cpp \
-					main.cpp
+			  config/Location.cpp \
+			  utils/StatusException.cpp \
+			  core/Kqueue.cpp \
+			  core/Event.cpp \
+			  core/Socket.cpp \
+			  core/Connection.cpp \
+			  core/ServerManager.cpp \
+			  core/EventLoop.cpp \
+			  http/Request.cpp \
+			  http/RequestParser.cpp \
+			  main.cpp
 
 OBJS		= $(SRCS:%.cpp=%.o)
 

--- a/core/Connection.hpp
+++ b/core/Connection.hpp
@@ -4,6 +4,9 @@
 #include <ctime>
 #include <string>
 
+#include "http/Request.hpp"
+#include "http/RequestParser.hpp"
+
 // 클라이언트 연결을 관리하는 클래스
 // - 임시 객체 (구현 예정)
 class Connection {
@@ -11,6 +14,9 @@ class Connection {
   int _fd;
   std::time_t _lastCallTime;
   std::string _requestString;
+
+  Request _request;
+  RequestParser _requestParser;
 
  public:
   Connection(int fd);

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -1,0 +1,126 @@
+#include "Request.hpp"
+
+// Constructor & Destructor
+
+Request::Request(void) : _method(HTTP_NONE) {}
+
+Request::Request(Request const& request) { *this = request; }
+
+Request::~Request(void) {}
+
+// Operator Overloading
+
+Request& Request::operator=(Request const& request) {
+  if (this != &request) {
+    _method = request._method;
+    _path = request._path;
+    _httpVersion = request._httpVersion;
+    _header = request._header;
+    _body = request._body;
+  }
+  return *this;
+}
+
+// debug
+
+#include <iostream>
+
+// 디버깅용 Request 정보 출력 함수
+void Request::print() {
+  std::cout << "Method: " << _method << std::endl;
+  std::cout << "Path: " << _path << std::endl;
+  std::cout << "HTTP Version: " << _httpVersion << std::endl;
+
+  std::cout << "Headers:" << std::endl;
+  for (std::map<std::string, std::vector<std::string> >::const_iterator it =
+           _header.begin();
+       it != _header.end(); ++it) {
+    std::cout << "header-field: [" << it->first << "] ";
+    for (std::vector<std::string>::const_iterator vit = it->second.begin();
+         vit != it->second.end(); ++vit) {
+      std::cout << "[" << *vit << "]" << std::endl;
+    }
+    std::cout << "---------" << std::endl;
+  }
+
+  std::cout << "Body: " << _body << std::endl;
+}
+
+// Public method - getter
+
+std::vector<std::string> const& Request::getHeaderFieldValues(
+    std::string const& fieldName) {
+  if (isHeaderFieldNameExists(fieldName) == false) {
+    throw std::runtime_error(
+        "[2203] Request: getHeaderFieldValues -  field-name does not exist");
+  }
+
+  return _header[fieldName];
+}
+
+// Public Method
+
+// - Request Line에 해당하는 method, path, http version 저장
+// - result 배열에는 method, path, httpVersion이 순서대로 저장되어 있다고 가정
+void Request::storeRequestLine(std::vector<std::string> const& result) {
+  int const methodIndex = 0, pathIndex = 1, httpVersionIndex = 2;
+
+  _method = matchEHttpMethod(result[methodIndex]);
+  _path = result[pathIndex];
+  _httpVersion = result[httpVersionIndex];
+}
+
+// - header field 저장
+// - result 배열에는 fieldName과 fieldValue가 순서대로 저장되어 있다고 가정
+void Request::storeHeaderField(std::vector<std::string> const& result) {
+  int const fieldNameIndex = 0, fieldValueIndex = 1;
+
+  std::string fieldName = result[fieldNameIndex];
+  std::vector<std::string> fieldValue;
+  fieldValue.push_back(result[fieldValueIndex]);
+  // - TODO:: , 로 구분될 수 있는 값 처리 필요
+  _header.insert(
+      std::pair<std::string, std::vector<std::string> >(fieldName, fieldValue));
+}
+
+// - body 저장
+void Request::storeBody(std::string const& result) { _body = result; }
+
+// 해당 헤더 field-name의 존재를 확인하는 함수
+bool Request::isHeaderFieldNameExists(std::string const& fieldName) {
+  return (_header.find(fieldName) != _header.end());
+}
+
+// 해당 헤더 field-value의 존재를 확인하는 함수
+// 해당 헤더 field-name이 없다면 false 반환
+bool Request::isHeaderFieldValueExists(std::string const& fieldName,
+                                       std::string const& fieldValue) {
+  if (isHeaderFieldNameExists(fieldName) == false) return false;
+
+  std::vector<std::string> const& fieldValues = _header[fieldName];
+  std::vector<std::string>::const_iterator it =
+      std::find(fieldValues.begin(), fieldValues.end(), fieldValue);
+  return (it != fieldValues.end());
+}
+
+// 멤버 변수를 비어있는 상태로 초기화
+// 단, _buffer는 제외
+void Request::clear() {
+  _method = HTTP_NONE;
+  _path.clear();
+  _httpVersion.clear();
+  _header.clear();
+  _body.clear();
+}
+
+// Private Method
+
+// method가 매칭되는 enum EHttpMethod를 반환
+// 매칭되는 EHttpMethod가 없는 경우 예외 발생
+EHttpMethod Request::matchEHttpMethod(std::string method) {
+  if (method == "GET") return HTTP_GET;
+  if (method == "POST") return HTTP_POST;
+  if (method == "DELETE") return HTTP_DELETE;
+  throw StatusException(HTTP_NOT_ALLOWED,
+                        "[2101] Request: matchEHttpMethod - invalid method");
+}

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -60,7 +60,7 @@ std::vector<std::string> const& Request::getHeaderFieldValues(
 
 // Public Method
 
-// - Request Line에 해당하는 method, path, http version 저장
+// Request Line에 해당하는 method, path, http version 저장
 // - result 배열에는 method, path, httpVersion이 순서대로 저장되어 있다고 가정
 void Request::storeRequestLine(std::vector<std::string> const& result) {
   int const methodIndex = 0, pathIndex = 1, httpVersionIndex = 2;
@@ -70,7 +70,7 @@ void Request::storeRequestLine(std::vector<std::string> const& result) {
   _httpVersion = result[httpVersionIndex];
 }
 
-// - header field 저장
+// Header field 저장
 // - result 배열에는 fieldName과 fieldValue가 순서대로 저장되어 있다고 가정
 void Request::storeHeaderField(std::vector<std::string> const& result) {
   int const fieldNameIndex = 0, fieldValueIndex = 1;
@@ -83,7 +83,7 @@ void Request::storeHeaderField(std::vector<std::string> const& result) {
       std::pair<std::string, std::vector<std::string> >(fieldName, fieldValue));
 }
 
-// - body 저장
+// body 저장
 void Request::storeBody(std::string const& result) { _body = result; }
 
 // 해당 헤더 field-name의 존재를 확인하는 함수
@@ -92,7 +92,7 @@ bool Request::isHeaderFieldNameExists(std::string const& fieldName) {
 }
 
 // 해당 헤더 field-value의 존재를 확인하는 함수
-// 해당 헤더 field-name이 없다면 false 반환
+// - 해당 헤더 field-name이 없다면 false 반환
 bool Request::isHeaderFieldValueExists(std::string const& fieldName,
                                        std::string const& fieldValue) {
   if (isHeaderFieldNameExists(fieldName) == false) return false;
@@ -104,7 +104,6 @@ bool Request::isHeaderFieldValueExists(std::string const& fieldName,
 }
 
 // 멤버 변수를 비어있는 상태로 초기화
-// 단, _buffer는 제외
 void Request::clear() {
   _method = HTTP_NONE;
   _path.clear();
@@ -116,7 +115,7 @@ void Request::clear() {
 // Private Method
 
 // method가 매칭되는 enum EHttpMethod를 반환
-// 매칭되는 EHttpMethod가 없는 경우 예외 발생
+// - 매칭되는 EHttpMethod가 없는 경우 예외 발생
 EHttpMethod Request::matchEHttpMethod(std::string method) {
   if (method == "GET") return HTTP_GET;
   if (method == "POST") return HTTP_POST;

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -5,8 +5,8 @@
 #include <string>
 #include <vector>
 
-#include "utils/Enum.hpp"
-#include "utils/StatusException.hpp"
+#include "../utils/Enum.hpp"
+#include "../utils/StatusException.hpp"
 
 // HTTP Request 클래스
 class Request {

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -1,0 +1,46 @@
+#ifndef __REQUEST_HPP__
+#define __REQUEST_HPP__
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "utils/Enum.hpp"
+#include "utils/StatusException.hpp"
+
+// HTTP Request 클래스
+class Request {
+ private:
+  enum EHttpMethod _method;
+  std::string _path;
+  std::string _httpVersion;
+  std::map<std::string, std::vector<std::string> > _header;
+  std::string _body;
+
+ public:
+  Request(void);
+  Request(Request const& request);
+  ~Request(void);
+
+  Request& operator=(Request const& request);
+
+  void print(void);  // debug
+
+  std::vector<std::string> const& getHeaderFieldValues(
+      std::string const& fieldName);
+
+  void storeRequestLine(std::vector<std::string> const& result);
+  void storeHeaderField(std::vector<std::string> const& result);
+  void storeBody(std::string const& result);
+
+  bool isHeaderFieldNameExists(std::string const& fieldName);
+  bool isHeaderFieldValueExists(std::string const& fieldName,
+                                std::string const& fieldValue);
+
+  void clear(void);
+
+ private:
+  EHttpMethod matchEHttpMethod(std::string method);
+};
+
+#endif

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -1,0 +1,316 @@
+#include "RequestParser.hpp"
+
+// Constructor & Destructor
+
+RequestParser::RequestParser(Request& request)
+    : _status(READY), _request(request), _bodyType(BODY_NONE), _bodyLength(0) {}
+
+RequestParser::RequestParser(RequestParser const& requestParser)
+    : _request(requestParser._request) {
+  *this = requestParser;
+}
+
+RequestParser::~RequestParser(void) {}
+
+// Operator Overloading
+
+RequestParser& RequestParser::operator=(RequestParser const& requestParser) {
+  if (this != &requestParser) {
+    _status = requestParser._status;
+    _requestLine = requestParser._requestLine;
+    _header = requestParser._header;
+    _body = requestParser._body;
+    _buffer = requestParser._buffer;
+    _request = requestParser._request;
+    _bodyType = requestParser._bodyType;
+    _bodyLength = requestParser._bodyLength;
+  }
+  return *this;
+}
+
+// Public Method - getter
+
+enum EParsingStatus RequestParser::getParsingStatus() { return _status; }
+
+// Public Method
+
+#include <iostream>
+
+// buffer 값 파싱
+// TODO: chunked 입력 파싱 처리
+void RequestParser::parse(u_int8_t* buffer, ssize_t bytesRead) {
+  std::cout << ">> [Request: parse()]" << std::endl;  // debug 출력
+  std::cout << _status << std::endl;                  // debug 출력
+
+  for (size_t i = 0; i < _requestLine.size(); i++) {  // debug 출력
+    std::cout << _requestLine[i];
+  }
+  std::cout << std::endl;
+
+  u_int8_t ch;
+
+  for (ssize_t i = 0; i < bytesRead; i++) {
+    ch = buffer[i];
+    switch (_status) {
+      case READY:
+        _requestLine = _buffer;
+        _buffer.clear();
+        _status = REQUEST_LINE;
+        // fallthrough
+      case REQUEST_LINE:
+        parseRequestLine(ch);
+        break;
+      case HEADER_FIELD:
+        parseHeaderField(ch);
+        break;
+      case BODY:
+        parseBody(ch);
+        break;
+      case DONE:
+        _buffer.push_back(ch);
+    }
+  }
+}
+
+// 멤버 변수를 비어있는 상태로 초기화
+// - _buffer 변수는 제외
+void RequestParser::clear() {
+  _status = READY;
+  _requestLine.clear();
+  _header.clear();
+  _body.clear();
+}
+
+// Private Method - setter
+
+// bodyLength 저장
+// - 만약 bodyLengthString 을 size_t로 변환 실패할 경우 예외 발생
+// - TODO: config에 있는 client_max_body_size 예외 처리 필요
+void RequestParser::setBodyLength(std::string const& bodyLengthString) {
+  std::stringstream ss;
+
+  if (bodyLengthString.size() < 1 or bodyLengthString[0] == '-') {
+    throw std::invalid_argument(
+        "[2001] RequestParser: setBodyLength - invalid type: " +
+        bodyLengthString);
+  }
+
+  ss << bodyLengthString;
+  ss >> _bodyLength;
+
+  if (ss.fail() or !ss.eof()) {
+    throw std::invalid_argument(
+        "[2002] RequestParser: setBodyLength - invalid type: " +
+        bodyLengthString);
+  }
+}
+
+// Private Method
+
+// RequestLine 파싱
+// - CRLF가 입력되었을 경우 입력이 끝났다고 정의
+void RequestParser::parseRequestLine(u_int8_t const& ch) {
+  _requestLine.push_back(ch);
+
+  if (ch == '\n' and isEndWithCRLF(_requestLine)) {
+    if (_requestLine.size() == 2) {
+      RequestParser::clear();
+      return;
+    }
+    std::vector<std::string> processResult;
+    processResult = processRequestLine();
+    _request.storeRequestLine(processResult);
+    _status = HEADER_FIELD;
+  }
+}
+
+// HeaderField 파싱
+// - CRLF가 입력되었을 경우 header field 한 줄의 입력이 끝났다고 정의
+// - 단, CRLF만 입력되었을 경우는 header field의 입력 종료로 처리
+void RequestParser::parseHeaderField(u_int8_t const& ch) {
+  _header.push_back(ch);
+
+  if (ch == '\n' and isEndWithCRLF(_header)) {
+    if (_header.size() == 2) {
+      _bodyType = checkBodyType();
+      _status = _bodyType == BODY_NONE ? DONE : BODY;
+      if (_bodyType == BODY_CONTENT_LENGTH) {
+        std::vector<std::string> const& contentLengthValues =
+            _request.getHeaderFieldValues("content-length");
+        setBodyLength(contentLengthValues[0]);
+      }
+      return;
+    }
+
+    std::vector<std::string> processResult;
+    processResult = processHeaderField();
+    _request.storeHeaderField(processResult);
+    _header.clear();
+  }
+}
+
+// body 파싱
+// - bodyLength 만큼 저장되었을 경우 status를 DONE으로 변경
+void RequestParser::parseBody(u_int8_t const& ch) {
+  if (_body.size() < _bodyLength) _body.push_back(ch);
+
+  if (_body.size() == _bodyLength) {
+    std::string processResult = processBody();
+    _request.storeBody(processResult);
+    _status = DONE;
+  }
+}
+
+// RequestLine 후처리
+// - size가 3이 아닌 경우 예외 발생
+std::vector<std::string> RequestParser::processRequestLine() {
+  removeCRLF(_requestLine);
+
+  std::vector<std::string> result;
+  splitRequestLine(result);
+
+  if (isInvalidFormatSize(result, 3)) {
+    throw StatusException(
+        HTTP_BAD_REQUEST,
+        "[2100] RequestParser: processRequestLine - invalid format size");
+  }
+  return result;
+}
+
+// HeaderField 후처리
+// - 한 줄의 입력을 처리
+// - size가 2가 아닌 경우 예외 발생
+// - field-name의 길이가 1 미만이거나 Whitespace로 끝나는 경우 예외 발생
+// - Request 객체에 이미 존재하는 field-name일 경우 예외 발생
+std::vector<std::string> RequestParser::processHeaderField() {
+  removeCRLF(_header);
+
+  std::vector<std::string> result;
+  splitHeaderField(result);
+
+  if (isInvalidFormatSize(result, 2)) {
+    throw StatusException(
+        HTTP_BAD_REQUEST,
+        "[2200] RequestParser: processHeaderField - invalid format size");
+  }
+
+  int const fieldNameIndex = 0, fieldValueIndex = 1;
+  if (result[fieldNameIndex].size() < 1 or
+      isWhitespace(result[fieldNameIndex].back())) {
+    throw StatusException(
+        HTTP_BAD_REQUEST,
+        "[2201] RequestParser: processHeaderField - No whitespace is "
+        "allowed between the header field-name and colon");
+  }
+
+  if (_request.isHeaderFieldNameExists(result[fieldNameIndex])) {
+    throw StatusException(
+        HTTP_BAD_REQUEST,
+        "[2202] RequestParser: processHeaderField - duplicate field-name");
+  }
+
+  toLowerCase(result[fieldNameIndex]);
+  result[fieldValueIndex] = trim(result[fieldValueIndex]);
+  return result;
+}
+
+// body 후처리
+// - vector 형식을 std::string으로 변환
+std::string RequestParser::processBody() {
+  std::string result(_body.begin(), _body.end());
+  return result;
+}
+
+// requestLine를 SP( )을 기준으로 split
+// - split한 결과는 매개변수 result에 저장
+void RequestParser::splitRequestLine(std::vector<std::string>& result) {
+  std::string requestLine(_requestLine.begin(), _requestLine.end());
+  std::stringstream ss(requestLine);
+  std::string token;
+
+  while (std::getline(ss, token, ' ')) {
+    result.push_back(token);
+  }
+}
+
+// header를 가장 처음 나온 COLON(:)을 기준으로 split
+// - split한 결과는 매개변수 result에 저장
+void RequestParser::splitHeaderField(std::vector<std::string>& result) {
+  std::string headerField(_header.begin(), _header.end());
+  size_t pos = headerField.find(COLON);
+
+  if (pos != std::string::npos) {
+    result.push_back(headerField.substr(0, pos));
+    result.push_back(headerField.substr(pos + 1));
+  }
+}
+
+// _request 객체의 현재 Body Type 검사 후 enum EBodyType 반환
+// - transfer-encoding 헤더 필드에 chunked라는 값이 존재하는 경우 BODY_CHUNKED
+// - content-length 헤더 필드가 존재하는 경우 BODY_CONTENT_LENGTH
+// - 이 외의 경우 BODY_NONE
+RequestParser::EBodyType RequestParser::checkBodyType() {
+  if (_request.isHeaderFieldValueExists("transfer-encoding", "chunked"))
+    return BODY_CHUNKED;
+
+  if (_request.isHeaderFieldNameExists("content-length"))
+    return BODY_CONTENT_LENGTH;
+
+  return BODY_NONE;
+}
+
+// result의 size가 인자로 받은 size와 일치하지 않는지 여부 반환
+bool RequestParser::isInvalidFormatSize(std::vector<std::string> const& result,
+                                        size_t size) {
+  return (result.size() != size);
+}
+
+// 인자로 받은 vec이 CRLF로 끝나는지 여부 반환
+// - vec의 size가 2 미만인 경우 false로 처리
+bool RequestParser::isEndWithCRLF(std::vector<u_int8_t> const& vec) {
+  if (vec.size() < 2) {
+    return false;
+  }
+
+  if (vec[vec.size() - 2] == '\r' and vec.back() == '\n') {
+    return true;
+  }
+
+  return false;
+}
+
+// vec에서 CRLF 제거
+// - 인자로 받은 vec이 CRLF로 끝난다고 가정
+// - vec의 size가 2 미만인 경우 2000 예외 발생
+void RequestParser::removeCRLF(std::vector<u_int8_t>& vec) {
+  if (vec.size() < 2) {
+    throw std::runtime_error(
+        "[2000] RequestParser: removeCRLF - CRLF does not exist for removal.");
+  }
+  vec.pop_back();
+  vec.pop_back();
+}
+
+// string을 모두 소문자로 변경
+void RequestParser::toLowerCase(std::string& str) {
+  for (std::string::iterator it = str.begin(); it != str.end(); ++it)
+    *it = std::tolower(static_cast<unsigned char>(*it));
+}
+
+// string의 선행, 후행 공백 제거
+std::string RequestParser::trim(std::string const& str) {
+  std::string::const_iterator it = str.begin();
+  while (it != str.end() && isWhitespace(*it)) {
+    ++it;
+  }
+
+  std::string::const_reverse_iterator rit = str.rbegin();
+  while (rit.base() != it && isWhitespace(*rit)) {
+    ++rit;
+  }
+
+  return std::string(it, rit.base());
+}
+
+// WhiteSpace(SP / HTAB) 인지 확인
+bool RequestParser::isWhitespace(int c) { return (c == SP or c == HTAB); }

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -38,7 +38,7 @@ enum EParsingStatus RequestParser::getParsingStatus() { return _status; }
 
 // buffer 값 파싱
 // TODO: chunked 입력 파싱 처리
-void RequestParser::parse(u_int8_t* buffer, ssize_t bytesRead) {
+void RequestParser::parse(u_int8_t const* buffer, ssize_t bytesRead) {
   std::cout << ">> [Request: parse()]" << std::endl;  // debug 출력
   std::cout << _status << std::endl;                  // debug 출력
 

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -55,7 +55,7 @@ class RequestParser {
 
   enum EParsingStatus getParsingStatus();
 
-  void parse(u_int8_t* buffer, ssize_t bytesRead);
+  void parse(u_int8_t const* buffer, ssize_t bytesRead);
   void clear();
 
  private:

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -1,0 +1,86 @@
+#ifndef __REQUEST_PARSER_HPP__
+#define __REQUEST_PARSER_HPP__
+
+#include <algorithm>
+#include <cctype>
+#include <map>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "Request.hpp"
+#include "utils/StatusException.hpp"
+
+#define HTAB 9
+#define SP 32
+#define COLON 58
+
+// TODO: chunk 처리
+enum EParsingStatus {
+  READY,
+  REQUEST_LINE,
+  HEADER_FIELD,
+  BODY,
+  DONE,
+};
+
+// RequestParser 클래스
+// - HTTP Request를 파싱해서 Request 객체에 저장
+class RequestParser {
+ private:
+  enum EBodyType {
+    BODY_NONE,
+    BODY_CHUNKED,
+    BODY_CONTENT_LENGTH,
+  };
+
+  enum EParsingStatus _status;
+  std::vector<u_int8_t> _requestLine;
+  std::vector<u_int8_t> _header;
+  std::vector<u_int8_t> _body;
+
+  std::vector<u_int8_t> _buffer;
+
+  Request& _request;
+
+  enum EBodyType _bodyType;
+  size_t _bodyLength;
+
+ public:
+  RequestParser(Request& request);
+  RequestParser(RequestParser const& request);
+  ~RequestParser(void);
+
+  RequestParser& operator=(RequestParser const& request);
+
+  enum EParsingStatus getParsingStatus();
+
+  void parse(u_int8_t* buffer, ssize_t bytesRead);
+  void clear();
+
+ private:
+  RequestParser(void);
+
+  void setBodyLength(std::string const& bodyLengthString);
+
+  void parseRequestLine(u_int8_t const& ch);
+  void parseHeaderField(u_int8_t const& ch);
+  void parseBody(u_int8_t const& ch);
+
+  std::vector<std::string> processRequestLine(void);
+  std::vector<std::string> processHeaderField(void);
+  std::string processBody(void);
+
+  void splitRequestLine(std::vector<std::string>& result);
+  void splitHeaderField(std::vector<std::string>& result);
+
+  enum EBodyType checkBodyType(void);
+  bool isInvalidFormatSize(std::vector<std::string> const& result, size_t size);
+  bool isEndWithCRLF(std::vector<u_int8_t> const& vec);
+  void removeCRLF(std::vector<u_int8_t>& vec);
+  void toLowerCase(std::string& str);
+  std::string trim(std::string const& str);
+  bool isWhitespace(int c);
+};
+
+#endif

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include "Request.hpp"
-#include "utils/StatusException.hpp"
+#include "../utils/StatusException.hpp"
 
 #define HTAB 9
 #define SP 32

--- a/utils/Enum.hpp
+++ b/utils/Enum.hpp
@@ -1,7 +1,7 @@
 #ifndef __ENUM_HPP__
 #define __ENUM_HPP__
 
-enum EHttpMethod { HTTP_GET, HTTP_POST, HTTP_DELETE };
+enum EHttpMethod { HTTP_NONE, HTTP_GET, HTTP_POST, HTTP_DELETE };
 
 enum EStatusCode {
   HTTP_OK = 200,


### PR DESCRIPTION
### Request, RequestParser 클래스 구현

- http 폴더에 추가
  <img width="200" alt="Screen Shot 2024-01-14 at 10 21 19 PM" src="https://github.com/wonyangs/webserv/assets/44529556/87d05031-7d9a-4386-a171-1e6635c94a3c">

### Request 클래스 설계
- RequestParser를 통해 파싱한 정보를 저장할 Request 객체 구현
- store 접두사가 붙은 함수들을 통해 해당하는 정보를 저장
  - 현재는 기본 버전이기 때문에 값 유효성 검사 없이 모두 저장
  - EHttpMethod만 enum으로 할당할 수 없는 값에 대해 2101 예외 발생

### RequestParser 기본 버전 구현
- Request에 대한 예외 처리가 많기 때문에, 파싱 뒷 부분 파트 구현을 위해서 값을 저장해 사용할 수 있을 정도로 구현 진행
- EParsingStatus의 값을 통해 파싱하는 파트를 확인 후 해당하는 부분 값을 저장
  - DONE 상태에서 들어오는 값은 _buffer에 저장 후 _requestLine에 추가
  - 적다보니 **buffer와 동일하게 실행되도록 리팩토링이 필요**하네요..
```c++

enum EParsingStatus {
  READY,
  REQUEST_LINE,
  HEADER_FIELD,
  BODY,
  DONE,
};

void RequestParser::parse(u_int8_t* buffer, ssize_t bytesRead) {
  u_int8_t ch;

  for (ssize_t i = 0; i < bytesRead; i++) {
    ch = buffer[i];
    switch (_status) {
      case READY:
        _requestLine = _buffer;
        _buffer.clear();
        _status = REQUEST_LINE;
        // fallthrough
      case REQUEST_LINE:
        parseRequestLine(ch);
        break;
      case HEADER_FIELD:
        parseHeaderField(ch);
        break;
      case BODY:
        parseBody(ch);
        break;
      case DONE:
        _buffer.push_back(ch);
    }
  }
}
``` 

**[ 파싱 로직 설명 ]**

1. request line을 CRLF를 입력받을 때까지로 정의한다.
  `request-line   = method SP request-target SP HTTP-version CRLF`
    - SP를 기준으로 나누었을 때 size가 3이 아닌 경우 400 Bad Request
    - Request 객체에 저장
        - method가 GET, POST, DELETE가 아닌 경우 [405 Not Allowed](https://developer.mozilla.org/ko/docs/Web/HTTP/Status/405)
    - RequestLine 입력할 때 CRLF만 들어올 경우는 무시하고 넘어간다.
      - RFC 7230 3.5
        <img width="847" alt="Screen Shot 2024-01-14 at 10 32 06 PM" src="https://github.com/wonyangs/webserv/assets/44529556/e3419237-eeca-41a9-b1a5-70cf9f408d36">

2. header 한 줄을 CRLF를 입력받을 때까지로 정의한다.
- 만약 CRLF만 들어올 경우, header 입력이 종료된다.
  - Content-Length 헤더가 없는 경우 DONE으로 상태 변경
- 처음 나오는 `:`을 기준으로 field-name과 field-value를 나눈다.
    - Host: www.example.com:8080과 같은 경우가 있기 때문
    - 이 때 size가 2가 아닌 경우 404 Bad Request
- field-name의 길이가 1 미만이거나 Whitespace로 끝나는 경우 400 Bad Request
- field-name은 대소문자를 구분하지 않음 → 소문자로 통일
- field-value의 선행, 후행 공백 제거

3. Content-Length 헤더가 존재하는 경우 길이만큼 body 저장
  - BODY_CHUNKED에 대해서는 처리되고 있지 않음
  - 길이만큼 모두 읽었을 경우 DONE으로 상태 변경
4. 상태가 DONE일 때 buffer에 값이 들어와있는 경우
  - 멤버 변수 _buffer 에 값 저장 (위에 언급한 부분 리팩토링 필요)

### 참고사항
- 추후 각 파싱 값의 유효성 검사, chunked 처리 등 자세하게 처리할 이슈 생성 필요

### Issue

- close #15 