### PR TITLE
[Feat] RequestParser 구조 변경

### DIFF
--- a/core/Connection.cpp
+++ b/core/Connection.cpp
@@ -8,12 +8,9 @@
 // Constructor & Destructor
 
 Connection::Connection(int fd)
-    : _fd(fd), _lastCallTime(std::time(0)), _requestParser(_request) {}
+    : _fd(fd), _lastCallTime(std::time(0)), _requestParser() {}
 
-Connection::Connection(Connection const& connection)
-    : _requestParser(_request) {
-  *this = connection;
-}
+Connection::Connection(Connection const& connection) { *this = connection; }
 
 Connection::~Connection(void) {}
 
@@ -24,7 +21,6 @@ Connection& Connection::operator=(Connection const& connection) {
     _fd = connection._fd;
     _lastCallTime = connection._lastCallTime;
     _requestParser = connection._requestParser;
-    _request = connection._request;
   }
   return *this;
 }
@@ -56,23 +52,21 @@ void Connection::receive(void) {
       std::cerr << "Exception thrown: " << e.what() << std::endl;
       _requestString.clear();
       _requestParser.clear();
-      _request.clear();
     }
     std::string str(reinterpret_cast<char*>(buffer), bytesRead);
     _requestString.append(str);
   }
 
-  std::cout << "   Buffer: " << buffer << std::endl;
-  this->_request.print();
-
   if (_requestParser.getParsingStatus() == DONE) {
+    Request const& request = _requestParser.getRequest();
+    request.print();
+
     std::cout << "[ Server: received request ]\n"
               << "-------------\n"
               << _requestString << "\n-------------" << std::endl;
     send();
     _requestString.clear();
     _requestParser.clear();
-    _request.clear();
   }
   updateLastCallTime();
 }

--- a/core/Connection.hpp
+++ b/core/Connection.hpp
@@ -15,7 +15,6 @@ class Connection {
   std::time_t _lastCallTime;
   std::string _requestString;
 
-  Request _request;
   RequestParser _requestParser;
 
  public:

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -21,12 +21,27 @@ Request& Request::operator=(Request const& request) {
   return *this;
 }
 
+// Public Method - getter
+
+enum EHttpMethod const& Request::getMethod(void) const { return _method; }
+
+std::string const& Request::getPath(void) const { return _path; }
+
+std::string const& Request::getHttpVersion(void) const { return _httpVersion; }
+
+std::map<std::string, std::vector<std::string> > const& Request::getHeader(
+    void) const {
+  return _header;
+}
+
+std::string const& Request::getBody(void) const { return _body; }
+
 // debug
 
 #include <iostream>
 
 // 디버깅용 Request 정보 출력 함수
-void Request::print() {
+void Request::print() const {
   std::cout << "Method: " << _method << std::endl;
   std::cout << "Path: " << _path << std::endl;
   std::cout << "HTTP Version: " << _httpVersion << std::endl;

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -24,7 +24,13 @@ class Request {
 
   Request& operator=(Request const& request);
 
-  void print(void);  // debug
+  enum EHttpMethod const& getMethod(void) const;
+  std::string const& getPath(void) const;
+  std::string const& getHttpVersion(void) const;
+  std::map<std::string, std::vector<std::string> > const& getHeader(void) const;
+  std::string const& getBody(void) const;
+
+  void print(void) const;  // debug
 
   std::vector<std::string> const& getHeaderFieldValues(
       std::string const& fieldName);

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -2,8 +2,8 @@
 
 // Constructor & Destructor
 
-RequestParser::RequestParser(Request& request)
-    : _status(READY), _request(request), _bodyType(BODY_NONE), _bodyLength(0) {}
+RequestParser::RequestParser(void)
+    : _status(READY), _bodyType(BODY_NONE), _bodyLength(0) {}
 
 RequestParser::RequestParser(RequestParser const& requestParser)
     : _request(requestParser._request) {
@@ -30,7 +30,9 @@ RequestParser& RequestParser::operator=(RequestParser const& requestParser) {
 
 // Public Method - getter
 
-enum EParsingStatus RequestParser::getParsingStatus() { return _status; }
+enum EParsingStatus RequestParser::getParsingStatus() const { return _status; }
+
+Request const& RequestParser::getRequest() const { return _request; }
 
 // Public Method
 
@@ -79,6 +81,7 @@ void RequestParser::clear() {
   _requestLine.clear();
   _header.clear();
   _body.clear();
+  _request.clear();
 }
 
 // Private Method - setter

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -8,8 +8,8 @@
 #include <string>
 #include <vector>
 
-#include "Request.hpp"
 #include "../utils/StatusException.hpp"
+#include "Request.hpp"
 
 #define HTAB 9
 #define SP 32
@@ -41,26 +41,25 @@ class RequestParser {
 
   std::vector<u_int8_t> _buffer;
 
-  Request& _request;
+  Request _request;
 
   enum EBodyType _bodyType;
   size_t _bodyLength;
 
  public:
-  RequestParser(Request& request);
-  RequestParser(RequestParser const& request);
+  RequestParser(void);
+  RequestParser(RequestParser const& requestParser);
   ~RequestParser(void);
 
-  RequestParser& operator=(RequestParser const& request);
+  RequestParser& operator=(RequestParser const& requestParser);
 
-  enum EParsingStatus getParsingStatus();
+  enum EParsingStatus getParsingStatus(void) const;
+  Request const& getRequest(void) const;
 
   void parse(u_int8_t const* buffer, ssize_t bytesRead);
   void clear();
 
  private:
-  RequestParser(void);
-
   void setBodyLength(std::string const& bodyLengthString);
 
   void parseRequestLine(u_int8_t const& ch);


### PR DESCRIPTION
### Request 클래스 getter 함수 구현
- Connection 객체에서 RequestParser의 getParser 함수로 반환된 const& 객체에서 사용될 예정
  - const 객체에서 getter만 사용할 수 있도록 함수에 const 키워드 추가
  - print 함수도 Connection에서 디버깅 시 출력 위해 const 키워드 추가

```c++
  enum EHttpMethod const& getMethod(void) const;
  std::string const& getPath(void) const;
  std::string const& getHttpVersion(void) const;
  std::map<std::string, std::vector<std::string> > const& getHeader(void) const;
  std::string const& getBody(void) const;

  void print(void) const;  // debug
``` 

### Connection 객체에 존재하던 _request 멤버 변수를 RequestParser로 이동
- Connection 객체 입장에서 Request 객체를 단순하게 VO 관점으로 바라보고 작업할 수 있도록 구현
  - Connection 객체에서 사용하는 경우, RequestParser 내부 getRequest 함수를 통해 const& 변수로 반환하여 사용
  ```c++
   Request const& RequestParser::getRequest() const { return _request; }
   ``` 
- getRequest 함수 구현
  - 회의할 때 DONE일때만 사용한다고 가정하였으나 const&로 반환되기 때문에 ParsingStatus를 고려하지 않음 
- 구조에 맞게 생성자 수정
- RequestParser의 clear() 함수 호출 시 _request 멤버 변수도 초기화되도록 함수 추가
- Connection 객체에서 저장하는 부분 실행 예시
  ```c++
    if (_requestParser.getParsingStatus() == DONE) {
      Request const& request = _requestParser.getRequest();
      request.print();
  
      _requestParser.clear();
    }
  ``` 