### PR TITLE
[Feat] Request 파싱 중 StorageBuffer에 저장된 버퍼 처리

### DIFF
--- a/core/Connection.hpp
+++ b/core/Connection.hpp
@@ -13,7 +13,6 @@ class Connection {
  private:
   int _fd;
   std::time_t _lastCallTime;
-  std::string _requestString;
 
   RequestParser _requestParser;
 
@@ -24,7 +23,10 @@ class Connection {
 
   Connection& operator=(Connection const& connection);
 
-  void receive(void);
+  void readSocket(void);
+  void readStorage(void);
+  bool isReadStorageRequired(void);
+
   void send(void);
   void sendErrorPage(int code);
 

--- a/core/ServerManager.cpp
+++ b/core/ServerManager.cpp
@@ -92,8 +92,17 @@ void ServerManager::handleConnection(Event event) {
 
   try {
     if (event.getType() == Event::READ) {
-      it->second.receive();
+      it->second.readSocket();
     } else if (event.getType() == Event::WRITE) {
+      // 응답 보내기
+      it->second.send();
+      Kqueue::removeWriteEvent(event.getFd());
+
+      if (it->second.isReadStorageRequired()) {
+        it->second.readStorage();
+        return;
+      }
+      Kqueue::addReadEvent(event.getFd());
       return;  // WRITE 이벤트 부분 구현
     }
   } catch (StatusException const& e) {

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -64,13 +64,15 @@ void Request::print() const {
 // Public method - getter
 
 std::vector<std::string> const& Request::getHeaderFieldValues(
-    std::string const& fieldName) {
+    std::string const& fieldName) const {
   if (isHeaderFieldNameExists(fieldName) == false) {
     throw std::runtime_error(
         "[2203] Request: getHeaderFieldValues -  field-name does not exist");
   }
 
-  return _header[fieldName];
+  std::map<std::string, std::vector<std::string> >::const_iterator it =
+      _header.find(fieldName);
+  return it->second;
 }
 
 // Public Method
@@ -102,7 +104,7 @@ void Request::storeHeaderField(std::vector<std::string> const& result) {
 void Request::storeBody(std::string const& result) { _body = result; }
 
 // 해당 헤더 field-name의 존재를 확인하는 함수
-bool Request::isHeaderFieldNameExists(std::string const& fieldName) {
+bool Request::isHeaderFieldNameExists(std::string const& fieldName) const {
   return (_header.find(fieldName) != _header.end());
 }
 

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -33,13 +33,13 @@ class Request {
   void print(void) const;  // debug
 
   std::vector<std::string> const& getHeaderFieldValues(
-      std::string const& fieldName);
+      std::string const& fieldName) const;
 
   void storeRequestLine(std::vector<std::string> const& result);
   void storeHeaderField(std::vector<std::string> const& result);
   void storeBody(std::string const& result);
 
-  bool isHeaderFieldNameExists(std::string const& fieldName);
+  bool isHeaderFieldNameExists(std::string const& fieldName) const;
   bool isHeaderFieldValueExists(std::string const& fieldName,
                                 std::string const& fieldValue);
 

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -20,7 +20,7 @@ RequestParser& RequestParser::operator=(RequestParser const& requestParser) {
     _requestLine = requestParser._requestLine;
     _header = requestParser._header;
     _body = requestParser._body;
-    _buffer = requestParser._buffer;
+    _storageBuffer = requestParser._storageBuffer;
     _request = requestParser._request;
     _bodyLength = requestParser._bodyLength;
     _chunkSizeBuffer = requestParser._chunkSizeBuffer;
@@ -56,8 +56,8 @@ void RequestParser::parse(u_int8_t const* buffer, ssize_t bytesRead) {
     ch = buffer[i];
     switch (_status) {
       case READY:
-        _requestLine = _buffer;
-        _buffer.clear();
+        _requestLine = _storageBuffer;
+        _storageBuffer.clear();
         _status = REQUEST_LINE;
         // fallthrough
       case REQUEST_LINE:
@@ -70,7 +70,7 @@ void RequestParser::parse(u_int8_t const* buffer, ssize_t bytesRead) {
         parseBodyContentLength(ch);
         break;
       case DONE:
-        _buffer.push_back(ch);
+        _storageBuffer.push_back(ch);
       default:
         break;  // TODO: chunk status 추가 후 default는 예외로 처리
     }
@@ -81,7 +81,7 @@ void RequestParser::parse(u_int8_t const* buffer, ssize_t bytesRead) {
 }
 
 // 멤버 변수를 비어있는 상태로 초기화
-// - _buffer 변수는 제외
+// - _storageBuffer 변수는 제외
 void RequestParser::clear() {
   _status = READY;
   _requestLine.clear();

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -47,6 +47,8 @@ Request const& RequestParser::getRequest() const { return _request; }
 void RequestParser::parse(u_int8_t const* buffer, ssize_t bytesRead) {
   if (_status == HEADER_FIELD_END) {
     setupBodyParse();
+
+    if (_status == DONE) return;
   }
 
   for (size_t i = 0; i < _storageBuffer.size(); i++) {
@@ -108,11 +110,17 @@ void RequestParser::setBodyLength(std::string const& bodyLengthString) {
 // - 남아있는 값에서 startIdx 이전 값들 삭제 후 buffer 값 추가
 void RequestParser::setStorageBuffer(size_t startIdx, u_int8_t const* buffer,
                                      ssize_t bytesRead) {
-  _storageBuffer.erase(_storageBuffer.begin(),
-                       _storageBuffer.begin() + startIdx);
-  for (ssize_t i = 0; i < bytesRead; i++) {
-    _storageBuffer.push_back(buffer[i]);
+  std::vector<u_int8_t> tmp;
+
+  for (size_t i = startIdx; i < _storageBuffer.size(); i++) {
+    tmp.push_back(_storageBuffer[i]);
   }
+  for (ssize_t i = 0; i < bytesRead; i++) {
+    tmp.push_back(buffer[i]);
+  }
+
+  _storageBuffer.clear();
+  _storageBuffer = tmp;
 }
 
 // Private Method

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -20,7 +20,11 @@ enum EParsingStatus {
   READY,
   REQUEST_LINE,
   HEADER_FIELD,
-  BODY,
+  HEADER_FIELD_END,
+  BODY_CONTENT_LENGTH,
+  BODY_CHUNKED,
+  BODY_CHUNK_SIZE,
+  BODY_CHUNK_DATA,
   DONE,
 };
 
@@ -28,12 +32,6 @@ enum EParsingStatus {
 // - HTTP Request를 파싱해서 Request 객체에 저장
 class RequestParser {
  private:
-  enum EBodyType {
-    BODY_NONE,
-    BODY_CHUNKED,
-    BODY_CONTENT_LENGTH,
-  };
-
   enum EParsingStatus _status;
   std::vector<u_int8_t> _requestLine;
   std::vector<u_int8_t> _header;
@@ -43,8 +41,10 @@ class RequestParser {
 
   Request _request;
 
-  enum EBodyType _bodyType;
   size_t _bodyLength;
+
+  std::vector<u_int8_t> _chunkSizeBuffer;
+  size_t _chunkSize;
 
  public:
   RequestParser(void);
@@ -64,7 +64,9 @@ class RequestParser {
 
   void parseRequestLine(u_int8_t const& ch);
   void parseHeaderField(u_int8_t const& ch);
-  void parseBody(u_int8_t const& ch);
+  void parseBodyContentLength(u_int8_t const& ch);
+
+  void setupBodyParse(void);
 
   std::vector<std::string> processRequestLine(void);
   std::vector<std::string> processHeaderField(void);
@@ -73,7 +75,7 @@ class RequestParser {
   void splitRequestLine(std::vector<std::string>& result);
   void splitHeaderField(std::vector<std::string>& result);
 
-  enum EBodyType checkBodyType(void);
+  EParsingStatus checkBodyParsingStatus(void);
   bool isInvalidFormatSize(std::vector<std::string> const& result, size_t size);
   bool isEndWithCRLF(std::vector<u_int8_t> const& vec);
   void removeCRLF(std::vector<u_int8_t>& vec);

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -37,7 +37,7 @@ class RequestParser {
   std::vector<u_int8_t> _header;
   std::vector<u_int8_t> _body;
 
-  std::vector<u_int8_t> _buffer;
+  std::vector<u_int8_t> _storageBuffer;
 
   Request _request;
 

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -62,9 +62,10 @@ class RequestParser {
  private:
   void setBodyLength(std::string const& bodyLengthString);
 
-  void parseRequestLine(u_int8_t const& ch);
-  void parseHeaderField(u_int8_t const& ch);
-  void parseBodyContentLength(u_int8_t const& ch);
+  void parseOctet(u_int8_t const& octet);
+  void parseRequestLine(u_int8_t const& octet);
+  void parseHeaderField(u_int8_t const& octet);
+  void parseBodyContentLength(u_int8_t const& octet);
 
   void setupBodyParse(void);
 

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -59,8 +59,12 @@ class RequestParser {
   void parse(u_int8_t const* buffer, ssize_t bytesRead);
   void clear();
 
+  bool isStorageBufferNotEmpty(void);
+
  private:
   void setBodyLength(std::string const& bodyLengthString);
+  void setStorageBuffer(size_t startIdx, u_int8_t const* buffer,
+                        ssize_t bytesRead);
 
   void parseOctet(u_int8_t const& octet);
   void parseRequestLine(u_int8_t const& octet);


### PR DESCRIPTION
### 입력 완료 상태에서 남은 버퍼 값 처리

- `_status`가 파싱 도중 `HEADER_FIELD_END` 또는 `DONE`이 되었을 경우 `buffer`에 파싱되지 않고 남은 octets을 RequestParser 멤버 변수인 `_storageBuffer`에 저장
- `_storageBuffer`에 저장된 값을 `buffer`보다 우선적으로 파싱 진행

1. `_status` 가 `HEADER_FIELD_END` 인 경우
  - `buffer`에 남아있는 값을 `_storageBuffer`에 저장
  - Location 블록 할당을 위해 파싱 중단 후 남은 버퍼 값에 대한 처리 필요
  - Location 블록 할당이 끝나면 다시 파싱 시작
2. `_status`가 `DONE` 인 경우
  - Request 파싱 종료 후 남은 버퍼 값은 `_storageBuffer`에 저장


### storageBuffer에 담긴 값이 있는 경우 커넥션 처리

- Connection 클래스에서 `readSocket()`, `readStorage() `함수를 따로 나누어 경우를 분리
- ServerManager 및 Connection 관련 함수에서 해당하는 관련 kqueue 이벤트 등록 및 제거
    ```c++
    // ServerManager::handleConnection 함수 일부분
    if (event.getType() == Event::READ) {
      it->second.readSocket();
    } else if (event.getType() == Event::WRITE) {
      // 응답 보내기
      it->second.send();
      Kqueue::removeWriteEvent(event.getFd());

      if (it->second.isReadStorageRequired()) {
        it->second.readStorage();
        return;
      }
      Kqueue::addReadEvent(event.getFd());
      return;  // WRITE 이벤트 부분 구현
    }
    ``` 
  - `readSocket()` : `DONE` 상태인 경우 read 제거, write 등록
  - `readStorage()` : `DONE` 상태인 경우 write 등록, 아닌 경우 read 등록
- `isReadStorageRequired()` 함수 구현
  - ServerManager에서 WRITE 이벤트를 받은 경우에 응답 전송 후 Storage를 읽어야 되는지 검사
  - Storage를 읽어야된다면 Connection의 `readStorage()` 함수 호출
- 추후 `readSocket()`, `readStorage()` 함수에서 반복되는 부분 함수화 필요

### 자잘한 수정
- `EBodyType` enum 삭제, `EParsingStatus`에 포함하도록 변경
- `_chunkSize`, `_chunkSizeBuffer` 멤버변수 추가
- RequestParser 클래스에서 socket에서 읽어오는 `buffer` 변수와 혼동으로 인해 `_buffer` 변수명을 `_storageBuffer`로 변경
- parse 함수 내부 로직을 `parseOctet` 함수로 분리 후 `ch` 변수명을 `octet`으로 통일
- RequestParser에서 반환되는 const Request 객체에서 사용할 함수 const 키워드 추가

### Issue
- close #21 