### PR TITLE
[Fix] 클라이언트가 연결을 종료했을 때 관리가 되지 않던 오류 수정

### DIFF
--- a/core/Connection.cpp
+++ b/core/Connection.cpp
@@ -27,6 +27,7 @@ Connection& Connection::operator=(Connection const& connection) {
   if (this != &connection) {
     _fd = connection._fd;
     _lastCallTime = connection._lastCallTime;
+    _status = connection._status;
     _requestParser = connection._requestParser;
   }
   return *this;
@@ -37,16 +38,14 @@ Connection& Connection::operator=(Connection const& connection) {
 // 요청 읽기
 // - 임시 메서드
 void Connection::readSocket(void) {
+  _status = ON_RECV;
   u_int8_t buffer[BUFFER_SIZE];
 
   memset(buffer, 0, BUFFER_SIZE);
   ssize_t bytesRead = ::read(_fd, buffer, sizeof(buffer) - 1);
-  _status = ON_RECV;
 
   if (bytesRead < 0) {
-    perror("read");
-    ::close(_fd);
-    return;
+    throw std::runtime_error("read error");
   } else if (bytesRead == 0) {
     // 클라이언트가 연결을 종료했음
     _status = CLOSE;

--- a/core/Connection.hpp
+++ b/core/Connection.hpp
@@ -10,9 +10,13 @@
 // 클라이언트 연결을 관리하는 클래스
 // - 임시 객체 (구현 예정)
 class Connection {
+ public:
+  enum EStatus {ON_WAIT, ON_RECV, TO_SEND, ON_SEND, CLOSE};
+
  private:
   int _fd;
   std::time_t _lastCallTime;
+  enum EStatus _status;
 
   RequestParser _requestParser;
 
@@ -33,6 +37,7 @@ class Connection {
   void close(void);
 
   int getFd(void) const;
+  EStatus getConnectionStatus(void) const;
   long getElapsedTime(void) const;
 
  private:

--- a/core/ServerManager.cpp
+++ b/core/ServerManager.cpp
@@ -93,6 +93,10 @@ void ServerManager::handleConnection(Event event) {
   try {
     if (event.getType() == Event::READ) {
       it->second.readSocket();
+      if (it->second.getConnectionStatus() == Connection::CLOSE) {
+        Kqueue::removeReadEvent(event.getFd());
+        removeConnection(event.getFd());
+      }
     } else if (event.getType() == Event::WRITE) {
       // 응답 보내기
       it->second.send();


### PR DESCRIPTION
## 오류 분석

1. 클라이언트가 연결을 종료하면 소켓이 EOF 상태로 변하고 **READ 이벤트가 발생**
2. Connection 클래스의 readSocket 함수로 가서 소켓을 읽으면 0바이트를 읽게 됨
3. 기존에는 아래 코드가 실행됐었음

```c++
if (bytesRead == 0) {
    // 클라이언트가 연결을 종료했음
    ::close(_fd);
    std::cout << "Client: connection closed" << std::endl;
    return;
```

- 현재 소켓 관리는 ServerManager에서 하고 있음
  - 소켓 상태가 업데이트 되면 ServerManager에 반영을 해줘야 함
- 위 코드에서는 자체적으로 소켓 연결을 끊어버림
  - 바뀐 소켓 상태가 ServerManager에 반영이 되지 않아 생긴 오류
 
## 오류 수정

### 1. Connection 상태 관리 추가

```c++
class Connection {
 public:
  enum EStatus {ON_WAIT, ON_RECV, TO_SEND, ON_SEND, CLOSE};
```
- 커넥션이 종료되었다는 상태를 알기 위해 현재 커넥션의 상태를 정의하는 enum 추가
  - ON_WAIT: 요청 대기 중
  - ON_RECV: 요청 읽는 중
  - TO_SEND: 응답 대기 중 (응답을 다 만든 상태)
  - ON_SEND: 응답 전송 중 (응답 내용을 다 전송하지 못한 상태, 응답 전송이 완료되면 ON_WAIT 상태로 바뀜)
  - CLOSE: 연결이 종료된 상태
- 추후 CGI 추가 등으로 상태가 많아지고 관리가 복잡해질 부분을 고려하여 미리 추가함 

### 2. 클라이언트로부터 종료된 경우 로직 수정

```c++
if (bytesRead == 0) {
    // 클라이언트가 연결을 종료했음
    _status = CLOSE;
    std::cout << "Client: connection closed" << std::endl;
    return;
  }
```

- 기존 코드와 달리 클라이언트로부터 연결이 종료됐음을 알게 된다면 CLOSE 상태로 바꾸고 나감

```c++
if (event.getType() == Event::READ) {
      it->second.readSocket();
      if (it->second.getConnectionStatus() == Connection::CLOSE) {
        Kqueue::removeReadEvent(event.getFd());
        removeConnection(event.getFd());
      }
    }
```

- ServerManager에서 읽기 이벤트에 대해 소켓을 읽었는데, 커넥션이 CLOSE 상태가 된 경우 클라이언트가 연결이 종료했다고 판단
  - 관련 이벤트 및 커넥션 제거

## 해결 이미지

<img width="350" alt="image" src="https://github.com/wonyangs/webserv/assets/43935708/cbb82b9e-7c31-4360-8c6b-b56a288f0b2b">

- 클라이언트가 **요청 -> 종료 -> 요청** 순으로 행동해도 정상적으로 동작함

## 이슈

- close: #24 

