### PR TITLE
[Feat] Chunked Transfer Coding 구현

### DIFF
--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -16,15 +16,15 @@ RequestParser::~RequestParser(void) {}
 
 RequestParser& RequestParser::operator=(RequestParser const& requestParser) {
   if (this != &requestParser) {
+    _request = requestParser._request;
     _status = requestParser._status;
     _requestLine = requestParser._requestLine;
     _header = requestParser._header;
     _body = requestParser._body;
     _storageBuffer = requestParser._storageBuffer;
-    _request = requestParser._request;
-    _bodyLength = requestParser._bodyLength;
     _chunkSizeBuffer = requestParser._chunkSizeBuffer;
     _chunkSize = requestParser._chunkSize;
+    _bodyLength = requestParser._bodyLength;
   }
   return *this;
 }
@@ -75,6 +75,9 @@ void RequestParser::clear() {
   _header.clear();
   _body.clear();
   _request.clear();
+  _chunkSizeBuffer.clear();
+  _chunkSize = 0;
+  _bodyLength = 0;
 }
 
 // _storageBuffer 변수가 비어있지 않은지 여부 확인

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -325,6 +325,12 @@ void RequestParser::splitRequestLine(std::vector<std::string>& result) {
   while (std::getline(ss, token, ' ')) {
     result.push_back(token);
   }
+
+  if (result.size() == 0) {
+    throw StatusException(
+        HTTP_BAD_REQUEST,
+        "[2102] RequestParser: splitRequestLine - requestLine is empty");
+  }
 }
 
 // header를 가장 처음 나온 COLON(:)을 기준으로 split
@@ -337,6 +343,12 @@ void RequestParser::splitHeaderField(std::vector<std::string>& result) {
     result.push_back(headerField.substr(0, pos));
     result.push_back(headerField.substr(pos + 1));
   }
+
+  if (result.size() == 0) {
+    throw StatusException(
+        HTTP_BAD_REQUEST,
+        "[2204] RequestParser: splitHeaderField - headerField is empty");
+  }
 }
 
 // chunkSizeBuffer SEMICOLON(;)을 기준으로 split
@@ -348,6 +360,12 @@ void RequestParser::splitBodyChunkSize(std::vector<std::string>& result) {
 
   while (std::getline(ss, token, ';')) {
     result.push_back(token);
+  }
+
+  if (result.size() == 0) {
+    throw StatusException(
+        HTTP_BAD_REQUEST,
+        "[2300] RequestParser: splitBodyChunkSize - chunkSizeBuffer is empty");
   }
 }
 

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -267,9 +267,9 @@ void RequestParser::parseBodyChunkSize(u_int8_t const& octet) {
 // chunk body에 대한 chunk-data 파싱
 // - chunk-size 만큼 chunk-data를 읽은 후 CRLF가 입력되지 않았을 경우 예외 발생
 void RequestParser::parseBodyChunkData(u_int8_t const& octet) {
-  const size_t crlfLength = 2;
+  size_t const crlfLength = 2;
 
-  const size_t bodySize = _body.size();
+  size_t const bodySize = _body.size();
   if ((bodySize == _bodyLength and octet != '\r') or
       (bodySize == _bodyLength + 1 and octet != '\n')) {
     throw StatusException(

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -15,7 +15,7 @@
 #define SP 32
 #define COLON 58
 
-// TODO: chunk 처리
+// TODO: chunk trailer 처리
 enum EParsingStatus {
   READY,
   REQUEST_LINE,
@@ -25,6 +25,7 @@ enum EParsingStatus {
   BODY_CHUNKED,
   BODY_CHUNK_SIZE,
   BODY_CHUNK_DATA,
+  BODY_CHUNK_END,
   DONE,
 };
 
@@ -63,6 +64,7 @@ class RequestParser {
 
  private:
   void setBodyLength(std::string const& bodyLengthString);
+  void setChunkSize(std::string const& chunkSizeString);
   void setStorageBuffer(size_t startIdx, u_int8_t const* buffer,
                         ssize_t bytesRead);
 
@@ -70,15 +72,18 @@ class RequestParser {
   void parseRequestLine(u_int8_t const& octet);
   void parseHeaderField(u_int8_t const& octet);
   void parseBodyContentLength(u_int8_t const& octet);
+  void parseBodyChunkSize(u_int8_t const& octet);
 
   void setupBodyParse(void);
 
   std::vector<std::string> processRequestLine(void);
   std::vector<std::string> processHeaderField(void);
   std::string processBody(void);
+  void processBodyChunkSize(void);
 
   void splitRequestLine(std::vector<std::string>& result);
   void splitHeaderField(std::vector<std::string>& result);
+  void splitBodyChunkSize(std::vector<std::string>& result);
 
   EParsingStatus checkBodyParsingStatus(void);
   bool isInvalidFormatSize(std::vector<std::string> const& result, size_t size);

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -15,7 +15,6 @@
 #define SP 32
 #define COLON 58
 
-// TODO: chunk trailer 처리
 enum EParsingStatus {
   READY = 0,
   REQUEST_LINE = 1,

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -33,19 +33,18 @@ enum EParsingStatus {
 // - HTTP Request를 파싱해서 Request 객체에 저장
 class RequestParser {
  private:
+  Request _request;
+
   enum EParsingStatus _status;
   std::vector<u_int8_t> _requestLine;
   std::vector<u_int8_t> _header;
   std::vector<u_int8_t> _body;
 
   std::vector<u_int8_t> _storageBuffer;
-
-  Request _request;
-
-  size_t _bodyLength;
-
   std::vector<u_int8_t> _chunkSizeBuffer;
+
   size_t _chunkSize;
+  size_t _bodyLength;
 
  public:
   RequestParser(void);

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -25,7 +25,7 @@ enum EParsingStatus {
   BODY_CHUNKED,
   BODY_CHUNK_SIZE,
   BODY_CHUNK_DATA,
-  BODY_CHUNK_END,
+  BODY_CHUNK_TRAILER,
   DONE,
 };
 
@@ -73,6 +73,7 @@ class RequestParser {
   void parseBodyContentLength(u_int8_t const& octet);
   void parseBodyChunkSize(u_int8_t const& octet);
   void parseBodyChunkData(u_int8_t const& octet);
+  void parseBodyChunkTrailer(u_int8_t const& octet);
 
   void setupBodyParse(void);
 

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -72,6 +72,7 @@ class RequestParser {
   void parseHeaderField(u_int8_t const& octet);
   void parseBodyContentLength(u_int8_t const& octet);
   void parseBodyChunkSize(u_int8_t const& octet);
+  void parseBodyChunkData(u_int8_t const& octet);
 
   void setupBodyParse(void);
 

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -17,16 +17,16 @@
 
 // TODO: chunk trailer 처리
 enum EParsingStatus {
-  READY,
-  REQUEST_LINE,
-  HEADER_FIELD,
-  HEADER_FIELD_END,
-  BODY_CONTENT_LENGTH,
-  BODY_CHUNKED,
-  BODY_CHUNK_SIZE,
-  BODY_CHUNK_DATA,
-  BODY_CHUNK_TRAILER,
-  DONE,
+  READY = 0,
+  REQUEST_LINE = 1,
+  HEADER_FIELD = 2,
+  HEADER_FIELD_END = 3,
+  BODY_CONTENT_LENGTH = 4,
+  BODY_CHUNKED = 5,
+  BODY_CHUNK_SIZE = 15,
+  BODY_CHUNK_DATA = 25,
+  BODY_CHUNK_TRAILER = 35,
+  DONE = 6,
 };
 
 // RequestParser 클래스
@@ -71,6 +71,7 @@ class RequestParser {
   void parseRequestLine(u_int8_t const& octet);
   void parseHeaderField(u_int8_t const& octet);
   void parseBodyContentLength(u_int8_t const& octet);
+  void parseBodyChunked(u_int8_t const& octet);
   void parseBodyChunkSize(u_int8_t const& octet);
   void parseBodyChunkData(u_int8_t const& octet);
   void parseBodyChunkTrailer(u_int8_t const& octet);


### PR DESCRIPTION
## 변경 사항

### Chunked Transfer Coding 구현
- chunked-body 요약 설명 : https://github.com/wonyangs/webserv/issues/20

**[ 파싱 로직 설명 ]**

1. Transfer-Encoding 헤더 필드에 chunked 가 있으면 chunked 입력 모드
    - `Transfer-Encoding: chunked` 라는 정확한 헤더가 입력되어야 chunk body 입력 가능
2. chunk-size 확인
    - CRLF 들어올 때까지 `_chunkSizeBuffer`에 저장
    - CRLF가 입력되면 chunk Size를 저장
        - `;`가 `_chunkSizeBuffer`에 포함되어 있으면 처음 나오는 `;` 기준으로 split해서 가장 처음 원소(`result[0]`)을 chunk-size로 설정
    - chunk-size가 0이면 last-chunk로 처리
    - chunk-size가 16진수로 올바르게 들어왔는지 확인 (아니라면 예외처리)
        - 대문자 소문자 모두 동일하게 16진수로 입력됨(A와 a를 동일하게 봄)
    - chunk-size가 올바르게 들어왔을 경우 16진수를 10진수로 변경해서 저장
    - chunk-size만큼 chunk-data 읽기
        - 다 읽고 CRLF가 안오면 예외 발생
    - last-chunk이 나올때까지 반복
3. trailer-part
    → 무시
    - CRLF 입력 시 입력 끝

### chunked 파싱 로직 분리
- 아래와 같이 chunked 관련 status는 10으로 나눈 나머지를 5로 통일
- `parseOctet()` 함수에서 `_status % 10` 으로 case 조건문 확인
- `switch-case` 문에서 `default` 조건은 예외(`runtime_error`)로 처리

```c++
enum EParsingStatus {
  READY = 0,
  REQUEST_LINE = 1,
  HEADER_FIELD = 2,
  HEADER_FIELD_END = 3,
  BODY_CONTENT_LENGTH = 4,
  BODY_CHUNKED = 5,
  BODY_CHUNK_SIZE = 15,
  BODY_CHUNK_DATA = 25,
  BODY_CHUNK_TRAILER = 35,
  DONE = 6,
};
``` 

### 실행 결과

<img width="700" alt="Screen Shot 2024-01-18 at 1 57 27 PM" src="https://github.com/wonyangs/webserv/assets/44529556/97d00a7d-6a88-49de-8581-becb8dde9bcf">


## To-do!

- 파싱 로직 1번에서 Transfer-Encoding 헤더 필드에 , 가 포함되어 있다면 , 기준으로 split
    - 헤더 부분 로직 추가할 때 다같이 할 예정
    - 현재는 chunked 라는 정확한 값 입력 시 chunk body 입력 가능
- chunk-ext 부분 (청크 확장자) 예외 처리
  - 현재 chunk-ext 는 무시하고 chunk-size만 사용
    <img width="636" alt="Screen Shot 2024-01-18 at 2 18 41 PM" src="https://github.com/wonyangs/webserv/assets/44529556/c8217433-b864-4865-b6ca-2db7b836c8aa">
