### PR TITLE
[Feat] location 블록 할당 구현

### DIFF
--- a/config/Server.hpp
+++ b/config/Server.hpp
@@ -24,15 +24,12 @@ class Server {
 
   Server& operator=(Server const& server);
 
-  // getter
   std::string const& getHostIp(void) const;
   int getPort(void) const;
 
-  // setter
   void addServerName(std::string const& serverName);
   void addLocationBlock(Location const& locationBlock);
 
-  // method
   Location const& getMatchedLocationBlock(std::string const& uri);
   bool hasDefaultLocationBlock(void);
   bool hasServerName(std::string const& host);

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -6,9 +6,11 @@
 
 #include "../http/Request.hpp"
 #include "../http/RequestParser.hpp"
+#include "ServerManager.hpp"
+
+class ServerManager;
 
 // 클라이언트 연결을 관리하는 클래스
-// - 임시 객체 (구현 예정)
 class Connection {
  public:
   enum EStatus { ON_WAIT, ON_RECV, TO_SEND, ON_SEND, CLOSE };
@@ -19,9 +21,10 @@ class Connection {
   enum EStatus _status;
 
   RequestParser _requestParser;
+  Location _location;
 
  public:
-  Connection(int fd);
+  Connection(int fd, ServerManager& manager);
   Connection(Connection const& connection);
   ~Connection(void);
 
@@ -42,8 +45,10 @@ class Connection {
 
  private:
   static int const BUFFER_SIZE = 1024;
+  ServerManager& _manager;
 
   void parseRequest(u_int8_t const* buffer, ssize_t bytesRead);
+  void setLocation(Request const& request);
 
   void updateLastCallTime(void);
   void setStatus(EStatus status);

--- a/server/ServerManager.hpp
+++ b/server/ServerManager.hpp
@@ -9,6 +9,8 @@
 #include "../core/Event.hpp"
 #include "Connection.hpp"
 
+class Connection;
+
 // 가상 서버 클래스
 class ServerManager {
  private:
@@ -32,6 +34,9 @@ class ServerManager {
 
   bool canHandleEvent(Event event) const;
   int getServerFd(void) const;
+
+  Location const& getDefaultLocation(void);
+  Location const& getLocation(std::string const& path, std::string const& host);
 
  private:
   static long const CONNECTION_LIMIT_TIME = 30;


### PR DESCRIPTION
## 변경 사항
### ServerManager 클래스 메서드 구현

- getDefaultLocation: 첫번째 서버의 기본 location 블록을 리턴. 초기화에 사용됨
- getLocation: path와 host에 해당하는 location 블록을 찾아 리턴

### Connection 클래스 location 블록 할당 로직 구현

- manager를 멤버 변수에 참조로 가지고 있도록 함
- location은 기본적으로 첫번째 서버의 기본 location 블록으로 설정
- 요청 헤더 파싱이 완료되면 해당하는 location 블록으로 변경

## 예제 config 파일
```text
# Server 1
server {
    listen 127.0.0.1:8080;
    server_name test.com www.test.com;

    location / {
        root /var/www/html;
        index index.html;
        limit_except GET POST;
        client_max_body_size 10000000;
        autoindex off;
        error_page 404 /404.html;
    }

    location /images/ {
        root /var/www/images;
        index index.html;
        limit_except GET;
        autoindex on;
    }
}

# Server 2
server {
    listen 127.0.0.1:8080;
    server_name test.org www.test.org;

    location / {
        root /var/www/html;
        index index.html;
        limit_except GET;
        client_max_body_size 8000000;
        autoindex on;
    }

    location /media/ {
        root /var/www/media;
        index index.html;
        limit_except GET POST;
        autoindex off;
    }
}
```

## 실행 예시
```text
< 예시 1 >

GET /images/ HTTP/1.1
host: test.com
```

<img width="200" alt="image" src="https://github.com/wonyangs/webserv/assets/43935708/67c3bf58-1f43-406d-8685-6f50a7729911">

- test.com의 /images/를 반환

```text
< 예시 2 >

GET /media/ HTTP/1.1
host: test.com
```

<img width="200" alt="image" src="https://github.com/wonyangs/webserv/assets/43935708/a5e12639-e051-4198-994e-d3ede97137a8">

- test.com에는 /media/가 없으므로 / 반환

```text
< 예시 3 >

GET /media/ HTTP/1.1
host: test.org
```

<img width="200" alt="image" src="https://github.com/wonyangs/webserv/assets/43935708/8010be3b-416b-411a-80b5-40610369809d">

- test.org의 /media/ 반환

```text
< 예시 4 >

GET /images/ HTTP/1.1
host: wonyang.com
```

<img width="200" alt="image" src="https://github.com/wonyangs/webserv/assets/43935708/c165beb7-5305-4632-8a92-ecbc2ed57ac8">

- wonyang.com은 존재하지 않으므로 첫번째 서버의 /images/ 반환

```text
< 예시 5 >

GET /images/ HTTP/1.1
host: www.test.org
```

<img width="200" alt="image" src="https://github.com/wonyangs/webserv/assets/43935708/fcf6bfd1-53cf-4e3b-82ca-10ddfcdd5304">

- www.test.org에는 /images/가 없으므로 / 반환

### issue

- close: #28 
