### PR TITLE
[Feat] request-target의 query 파싱

### DIFF
--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -1,5 +1,7 @@
 #include "Request.hpp"
 
+#include "Config.hpp"
+
 // Constructor & Destructor
 
 Request::Request(void) : _method(HTTP_NONE) {}
@@ -83,6 +85,11 @@ void Request::storeRequestLine(std::vector<std::string> const& result) {
   int const methodIndex = 0, pathIndex = 1, httpVersionIndex = 2;
 
   _method = matchEHttpMethod(result[methodIndex]);
+  if (Config::MAX_URI_SIZE < result[pathIndex].size()) {
+    throw StatusException(
+        HTTP_REQUEST_URI_TOO_LARGE,
+        "[2103] Request: storeRequestLine - path is too long");
+  }
   _path = result[pathIndex];
   _httpVersion = result[httpVersionIndex];
 }

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -16,6 +16,7 @@ Request& Request::operator=(Request const& request) {
   if (this != &request) {
     _method = request._method;
     _path = request._path;
+    _query = request._query;
     _httpVersion = request._httpVersion;
     _header = request._header;
     _body = request._body;
@@ -29,6 +30,8 @@ enum EHttpMethod const& Request::getMethod(void) const { return _method; }
 
 std::string const& Request::getPath(void) const { return _path; }
 
+std::string const& Request::getQuery(void) const { return _query; }
+
 std::string const& Request::getHttpVersion(void) const { return _httpVersion; }
 
 std::map<std::string, std::vector<std::string> > const& Request::getHeader(
@@ -37,33 +40,6 @@ std::map<std::string, std::vector<std::string> > const& Request::getHeader(
 }
 
 std::string const& Request::getBody(void) const { return _body; }
-
-// debug
-
-#include <iostream>
-
-// 디버깅용 Request 정보 출력 함수
-void Request::print() const {
-  std::cout << "Method: " << _method << std::endl;
-  std::cout << "Path: " << _path << std::endl;
-  std::cout << "HTTP Version: " << _httpVersion << std::endl;
-
-  std::cout << "Headers:" << std::endl;
-  for (std::map<std::string, std::vector<std::string> >::const_iterator it =
-           _header.begin();
-       it != _header.end(); ++it) {
-    std::cout << "header-field: [" << it->first << "] ";
-    for (std::vector<std::string>::const_iterator vit = it->second.begin();
-         vit != it->second.end(); ++vit) {
-      std::cout << "[" << *vit << "]" << std::endl;
-    }
-    std::cout << "---------" << std::endl;
-  }
-
-  std::cout << "Body: " << _body << std::endl;
-}
-
-// Public method - getter
 
 std::vector<std::string> const& Request::getHeaderFieldValues(
     std::string const& fieldName) const {
@@ -75,6 +51,31 @@ std::vector<std::string> const& Request::getHeaderFieldValues(
   std::map<std::string, std::vector<std::string> >::const_iterator it =
       _header.find(fieldName);
   return it->second;
+}
+
+// debug
+
+#include <iostream>
+
+// 디버깅용 Request 정보 출력 함수
+void Request::print() const {
+  std::cout << "Method: " << _method << std::endl;
+  std::cout << "Path: " << _path << std::endl;
+  std::cout << "Query: " << _query << std::endl;
+  std::cout << "HTTP Version: " << _httpVersion << std::endl;
+
+  std::cout << "Headers:" << std::endl;
+  for (std::map<std::string, std::vector<std::string> >::const_iterator it =
+           _header.begin();
+       it != _header.end(); ++it) {
+    std::cout << "header-field: [" << it->first << "] ";
+    for (std::vector<std::string>::const_iterator vit = it->second.begin();
+         vit != it->second.end(); ++vit) {
+      std::cout << "[" << *vit << "]" << std::endl;
+    }
+  }
+
+  std::cout << "Body: " << _body << std::endl;
 }
 
 // Public Method
@@ -131,6 +132,7 @@ bool Request::isHeaderFieldValueExists(std::string const& fieldName,
 void Request::clear() {
   _method = HTTP_NONE;
   _path.clear();
+  _query.clear();
   _httpVersion.clear();
   _header.clear();
   _body.clear();

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -76,20 +76,6 @@ std::vector<std::string> const& Request::getHeaderFieldValues(
   return it->second;
 }
 
-// Public Method - setter
-
-void Request::setMethod(std::string const& method) {
-  _method = matchEHttpMethod(method);
-}
-
-void Request::setPath(std::string const& path) { _path = path; }
-
-void Request::setQuery(std::string const& query) { _query = query; }
-
-void Request::setHttpVersion(std::string const& httpVersion) {
-  _httpVersion = httpVersion;
-}
-
 // Public Method
 
 // Request Line에 해당하는 method, request-target, http version 저장
@@ -155,6 +141,20 @@ void Request::clear() {
   _httpVersion.clear();
   _header.clear();
   _body.clear();
+}
+
+// Private Method - setter
+
+void Request::setMethod(std::string const& method) {
+  _method = matchEHttpMethod(method);
+}
+
+void Request::setPath(std::string const& path) { _path = path; }
+
+void Request::setQuery(std::string const& query) { _query = query; }
+
+void Request::setHttpVersion(std::string const& httpVersion) {
+  _httpVersion = httpVersion;
 }
 
 // Private Method

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -38,11 +38,6 @@ class Request {
 
   void print(void) const;  // debug
 
-  void setMethod(std::string const& method);
-  void setPath(std::string const& path);
-  void setQuery(std::string const& query);
-  void setHttpVersion(std::string const& httpVersion);
-
   void storeRequestLine(std::vector<std::string> const& result);
   void storeHeaderField(std::vector<std::string> const& result);
   void storeBody(std::string const& result);
@@ -54,6 +49,11 @@ class Request {
   void clear(void);
 
  private:
+  void setMethod(std::string const& method);
+  void setPath(std::string const& path);
+  void setQuery(std::string const& query);
+  void setHttpVersion(std::string const& httpVersion);
+
   EHttpMethod matchEHttpMethod(std::string method);
   void splitRequestTarget(std::string& path, std::string& query,
                           const std::string& requestTarget);

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -13,6 +13,7 @@ class Request {
  private:
   enum EHttpMethod _method;
   std::string _path;
+  std::string _query;
   std::string _httpVersion;
   std::map<std::string, std::vector<std::string> > _header;
   std::string _body;
@@ -26,14 +27,15 @@ class Request {
 
   enum EHttpMethod const& getMethod(void) const;
   std::string const& getPath(void) const;
+  std::string const& getQuery(void) const;
   std::string const& getHttpVersion(void) const;
   std::map<std::string, std::vector<std::string> > const& getHeader(void) const;
   std::string const& getBody(void) const;
 
-  void print(void) const;  // debug
-
   std::vector<std::string> const& getHeaderFieldValues(
       std::string const& fieldName) const;
+
+  void print(void) const;  // debug
 
   void storeRequestLine(std::vector<std::string> const& result);
   void storeHeaderField(std::vector<std::string> const& result);

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "../utils/Config.hpp"
 #include "../utils/Enum.hpp"
 #include "../utils/StatusException.hpp"
 
@@ -37,6 +38,11 @@ class Request {
 
   void print(void) const;  // debug
 
+  void setMethod(std::string const& method);
+  void setPath(std::string const& path);
+  void setQuery(std::string const& query);
+  void setHttpVersion(std::string const& httpVersion);
+
   void storeRequestLine(std::vector<std::string> const& result);
   void storeHeaderField(std::vector<std::string> const& result);
   void storeBody(std::string const& result);
@@ -49,6 +55,8 @@ class Request {
 
  private:
   EHttpMethod matchEHttpMethod(std::string method);
+  void splitRequestTarget(std::string& path, std::string& query,
+                          const std::string& requestTarget);
 };
 
 #endif

--- a/utils/Config.hpp
+++ b/utils/Config.hpp
@@ -11,6 +11,8 @@ class Config {
   static const int MIN_LIMIT_BODY_SIZE = 0;
   // 서버가 처리할 수 있는 최대 body 크기
   static const int MAX_LIMIT_BODY_SIZE = 100000000;
+  // 서버가 처리할 수 있는 최대 URI 크기
+  static const int MAX_URI_SIZE = 8000;
 
   // 상태코드 메시지
   static const std::map<int, std::string> statusMessages;


### PR DESCRIPTION
## 구현 사항

### 414(URI TOO LARGE) 예외 처리
> A server that receives a equest-target longer than any URI it wishes to parse MUST respond with a 414 (URI Too Long) status code (see Section 6.5.12 of [RFC7231]).
- utils/Config.hpp에 `MAX_URI_SIZE = 8000`으로 정의
- Request 객체 내부에서 storeRequestLine 실행 시 request-target size 검사 후 8000 초과 시 예외 발생

### query 파싱

```bnf
origin-form    = absolute-path [ "?" query ]
```

- request-target을 path와 query로 나누어 저장
- request-line 멤버 변수에 해당하는 setter 함수 구현
- request-target을 ?을 기준으로 split하는 함수 구현
- 이후 cgi에서 QUERY_STRING 환경변수 값으로 설정될 예정

### 실행 결과

<img width="1175" alt="Screen Shot 2024-01-18 at 9 43 45 PM" src="https://github.com/wonyangs/webserv/assets/44529556/70ac1924-e258-4682-a72a-dd2c8f4313ef">

## To-do!

- request-target에 대한 octet 유효성 검사 필요
  - 포함될 수 있는 문자열만 들어갔는지 확인
- cgi 구현 시 query의 `pct-encoded`을 디코딩 하는 과정 추가