### PR TITLE
[Feat] Response 클래스 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ SRCS		= config/Server.cpp \
 			  server/EventLoop.cpp \
 			  http/Request.cpp \
 			  http/RequestParser.cpp \
+			  http/Response.cpp \
 			  main.cpp
 
 OBJS		= $(SRCS:%.cpp=%.o)

--- a/http/Response.cpp
+++ b/http/Response.cpp
@@ -1,0 +1,100 @@
+#include "Response.hpp"
+
+// Constructor & Destructor
+
+Response::Response(void)
+    : _responseContent(""),
+      _startIndex(-1),
+      _httpVersion(""),
+      _statusCode(-1),
+      _body("") {}
+
+Response::Response(Response const& response) { *this = response; }
+
+Response::~Response(void) {}
+
+// Operator Overloading
+
+Response& Response::operator=(Response const& response) {
+  if (this != &response) {
+    _responseContent = response._responseContent;
+    _startIndex = response._startIndex;
+    _httpVersion = response._httpVersion;
+    _statusCode = response._statusCode;
+    _header = response._header;
+    _body = response._body;
+  }
+  return *this;
+}
+
+// debug
+
+#include <iostream>
+
+// 디버깅용 Response 정보 출력 함수
+void Response::print() const {
+  std::cout << "Response Content: " << _responseContent << std::endl;
+  std::cout << "Start Index: " << _startIndex << std::endl;
+  std::cout << "HTTP Version: " << _httpVersion << std::endl;
+  std::cout << "StatusCode: " << _statusCode << std::endl;
+
+  std::cout << "Headers:" << std::endl;
+  for (std::map<std::string, std::string>::const_iterator it = _header.begin();
+       it != _header.end(); ++it) {
+    std::cout << "header-field: [" << it->first << "] ";
+    std::cout << "[" << it->second << "]" << std::endl;
+  }
+
+  std::cout << "Body: " << _body << std::endl;
+}
+
+// Public Method - getter
+
+std::string const& Response::getHttpVersion(void) const { return _httpVersion; }
+
+int const& Response::getStatusCode(void) const { return _statusCode; }
+
+std::map<std::string, std::string> const& Response::getHeader(void) const {
+  return _header;
+}
+
+std::string const& Response::getBody(void) const { return _body; }
+
+// Public Method - setter
+
+void Response::setHttpVersion(std::string const& httpVersion) {
+  _httpVersion = httpVersion;
+}
+
+void Response::setMethod(int const& statusCode) { _statusCode = statusCode; }
+
+// Public Method
+
+// _header 멤버 변수에 fieldName을 key로, fieldValue를 value로 저장
+// - 만약 중복된 헤더인 경우 예외 발생
+void Response::addHeader(std::string const& fieldName,
+                         std::string const& fieldValue) {
+  if (isHeaderFieldNameExists(fieldName)) {
+    throw std::runtime_error(
+        "[5000] Response: addHeader - duplicate header field-name");
+  }
+  _header.insert(std::pair<std::string, std::string>(fieldName, fieldValue));
+}
+
+// _body 멤버 변수에 인자를 붙여서 저장
+void Response::appendBody(std::string const& body) { _body.append(body); }
+
+// 멤버 변수를 비어있는 상태로 초기화
+void Response::clear(void) {
+  _responseContent.clear();
+  _startIndex = -1;
+  _httpVersion.clear();
+  _statusCode = -1;
+  _header.clear();
+  _body.clear();
+}
+
+// 해당 헤더 field-name의 존재를 확인하는 함수
+bool Response::isHeaderFieldNameExists(std::string const& fieldName) const {
+  return (_header.find(fieldName) != _header.end());
+}

--- a/http/Response.hpp
+++ b/http/Response.hpp
@@ -1,0 +1,49 @@
+#ifndef __RESPONSE_HPP__
+#define __RESPONSE_HPP__
+
+#include <exception>
+#include <map>
+#include <string>
+
+#include "../utils/Config.hpp"
+#include "../utils/Enum.hpp"
+#include "../utils/StatusException.hpp"
+
+// HTTP Response 클래스
+class Response {
+ private:
+  std::string _responseContent;
+  ssize_t _startIndex;
+
+  std::string _httpVersion;
+  int _statusCode;
+  std::map<std::string, std::string> _header;
+  std::string _body;
+
+ public:
+  Response(void);
+  Response(Response const& response);
+  ~Response(void);
+
+  Response& operator=(Response const& response);
+
+  void print(void) const;  // debug
+
+  std::string const& getHttpVersion(void) const;
+  int const& getStatusCode(void) const;
+  std::map<std::string, std::string> const& getHeader(void) const;
+  std::string const& getBody(void) const;
+
+  void setHttpVersion(std::string const& httpVersion);
+  void setMethod(int const& statusCode);
+
+  void addHeader(std::string const& fieldName, std::string const& fieldValue);
+  void appendBody(std::string const& body);
+
+  void clear(void);
+
+ private:
+  bool isHeaderFieldNameExists(std::string const& fieldName) const;
+};
+
+#endif


### PR DESCRIPTION
## 구현 사항

### Response 클래스 구현
- `http` 폴더에 위치
- 현재 필요해보이는 것으로 미리 구현 (추후 수정될 수 있음)
- `_responseContent`는 실제로 클라이언트에 보낼 응답 최종 문자열을 저장
- `_startIndex`는 클라이언트에 `_responseContent`를 전송할 때 사용할 예정
  - 클라이언트에 응답을 보낼 때 버퍼만큼 보내기 때문에 필요할 것으로 예상
- `_statusCode`는 enum으로 처리할까 하다 일단 int로 저장
  - 초기화 시 -1로 저장됨

```c++
class Response {
 private:
  std::string _responseContent;
  ssize_t _startIndex;

  std::string _httpVersion;
  int _statusCode;
  std::map<std::string, std::string> _header;
  std::string _body;
  
  ...
}
``` 

### To-do!
- 테스트 때문에 실행했을 때 현재 Host 정보가 헤더에 포함되지 않는 경우 500 예외 발생
  - HTTP/1.1에서는 Host 헤더가 없는 경우 400 Bad Request 예상
  - HTTP/1.0에서는 Host 헤더가 없을 경우 빈 문자열로 처리 예상