### PR TITLE
[Feat] Kqueue 모든 이벤트 제거 기능 추가

### DIFF
--- a/core/Kqueue.cpp
+++ b/core/Kqueue.cpp
@@ -136,10 +136,10 @@ void Kqueue::removeAllEvents(int fd) {
 // - fd, 이벤트 타입. 등록/삭제를 선택
 void Kqueue::updateEventStatus(int fd, EEventType event, EEventAction action) {
   switch (action) {
-    case ADD_EVENT:
+    case ADD:
       _events[fd] |= event;
       break;
-    case REMOVE_EVENT:
+    case REMOVE:
       _events[fd] &= ~event;
       if (_events[fd] == NO_EVENT) {
         _events.erase(fd);

--- a/core/Kqueue.hpp
+++ b/core/Kqueue.hpp
@@ -11,6 +11,7 @@ class Kqueue {
  private:
   static int _fd;
   static struct timespec _timeout;
+  static std::map<int, int> _events;
 
  public:
   static void start(void);
@@ -21,9 +22,16 @@ class Kqueue {
   static void removeReadEvent(int fd);
   static void removeWriteEvent(int fd);
 
+  static void removeAllEvents(int fd);
+
   static Event getEvent(void);
 
  private:
+  enum EEventAction { ADD, REMOVE };
+  enum EEventType { NO_EVENT = 0, READ_EVENT = 1 << 0, WRITE_EVENT = 1 << 1 };
+
+  static void updateEventStatus(int fd, EEventType event, EEventAction action);
+
   Kqueue(void);
   Kqueue(Kqueue const& kqueue);
   ~Kqueue(void);

--- a/core/Kqueue.hpp
+++ b/core/Kqueue.hpp
@@ -4,6 +4,8 @@
 #include <sys/event.h>
 #include <time.h>
 
+#include <map>
+
 #include "Event.hpp"
 
 // kqueue를 관리하는 정적 클래스

--- a/server/ServerManager.cpp
+++ b/server/ServerManager.cpp
@@ -272,6 +272,7 @@ void ServerManager::removeConnection(int fd) {
   }
 
   Connection& connection = it->second;
+  Kqueue::removeAllEvents(fd);
   connection.close();
   _connections.erase(fd);
 }


### PR DESCRIPTION
## Kqueue 클래스

```c++
static std::map<int, int> _events;

enum EEventType { NO_EVENT = 0, READ_EVENT = 1 << 0, WRITE_EVENT = 1 << 1 };
```

- 이벤트를 비트마다 할당하여 map에서 관리하도록 구현
- 새로운 이벤트가 있을 시 `1 << 2`, `1 << 3` .. 와 같이 추가

```c++
Kqueue::removeAllEvents(fd);
```

- 해당하는 fd로 등록된 모든 이벤트 제거

## Connection 클래스

```c++
void ServerManager::removeConnection(int fd) {
  ConnectionMap::iterator it = _connections.find(fd);
  //...

  Connection& connection = it->second;
  Kqueue::removeAllEvents(fd);
  connection.close();
  _connections.erase(fd);
}
```

- connection을 종료할 때 클라이언트 fd로 등록된 모든 이벤트를 제거하도록 추가

## issue

- close: #31 