### PR TITLE
[Feat] 기본 에러 페이지 구현

### DIFF
--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -163,13 +163,16 @@ void Connection::sendErrorPage(int code) {
     it = Config::statusMessages.find(500);
   }
 
-  // HTTP 응답 생성
-  std::string response =
-      "HTTP/1.1 " + std::to_string(code) + " " + it->second + "\n" +
-      "Content-Length: 13\n"  // 내용 길이는 실제 내용에 맞게 조정 필요
-      + "Content-Type: text/plain\n" + "Connection: keep-alive\n\n" +
-      "Hello, world!\n\n";
+  std::string codeString = std::to_string(code);
 
+  // HTTP 응답 생성
+  std::string const& body =
+      Config::defaultErrorPageBody(codeString, it->second);
+
+  std::string response =
+      "HTTP/1.1 " + codeString + " " + it->second + "\n" +
+      "Content-Length: " + std::to_string(body.size()) +
+      "\nContent-Type: text/html\nConnection: keep-alive\n\n" + body;
   ssize_t bytesSent = write(_fd, response.c_str(), response.length());
 
   if (bytesSent < 0) {

--- a/utils/Config.cpp
+++ b/utils/Config.cpp
@@ -34,3 +34,27 @@ std::map<int, std::string> Config::initializeStatusMessages(void) {
   messages[504] = "Gateway Timeout";
   return messages;
 }
+
+std::string const Config::defaultErrorPageBody(std::string const& code,
+                                               std::string const& message) {
+  std::string const body =
+      "<!DOCTYPE html> <html> <head> <title>ERROR</title> <style> "
+      "@font-face { font-family: 'WarhavenB'; src: "
+      "url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2312-1@1.1/"
+      "WarhavenB.woff2') format('woff2'); font-weight: 700; font-style: "
+      "normal; } body {font-family: 'WarhavenB', Arial, sans-serif; "
+      "background-color: #d7ddcd; margin: 0; padding: 0; display: flex; "
+      "align-items: center; text-align: center; } .container { margin: "
+      "50px auto; animation: shake 0.5s cubic-bezier(.36,.07,.19,.97) both; "
+      "transform: translate3d(0, 0, 0); backface-visibility: hidden; "
+      "perspective: 1000px; } .error { font-size: 100px; color: #313438bd; } "
+      "@keyframes shake { 10%, 90% { transform: translate3d(-1px, 0, 0);} "
+      "20%, 80% { transform: translate3d(2px, 0, 0); } 30%, 50%, 70% {  "
+      "transform: translate3d(-4px, 0, 0); } 40%, 60% {  transform: "
+      "translate3d(4px, 0, 0);}} </style> </head> <body> <div class= "
+      "\"container \"> <h1 class=\"error\">" +
+      code + " " + message + "</h1> <img src=\" https://http.cat/" + code +
+      "\"alt=\"Error Image\" class=\"error-image\"> </div> </body>\n\n";
+
+  return body;
+}

--- a/utils/Config.cpp
+++ b/utils/Config.cpp
@@ -6,9 +6,31 @@ const std::map<int, std::string> Config::statusMessages =
 std::map<int, std::string> Config::initializeStatusMessages(void) {
   std::map<int, std::string> messages;
   messages[200] = "OK";
+  messages[201] = "Created";
+  messages[204] = "No Content";
+  messages[206] = "Partial Content";
+  messages[300] = "Multiple Choices";
+  messages[301] = "Moved Permanently";
+  messages[302] = "Found";
+  messages[304] = "Not Modified";
+  messages[307] = "Temporary Redirect";
   messages[400] = "Bad Request";
+  messages[401] = "Unauthorized";
+  messages[403] = "Forbidden";
   messages[404] = "Not Found";
-  messages[405] = "Http Not Allowed";
+  messages[405] = "Method Not Allowed";
+  messages[406] = "Not Acceptable";
+  messages[408] = "Request Timeout";
+  messages[409] = "Conflict";
+  messages[410] = "Gone";
+  messages[413] = "Payload Too Large";
+  messages[414] = "URI Too Long";
+  messages[415] = "Unsupported Media Type";
+  messages[429] = "Too Many Requests";
   messages[500] = "Internal Server Error";
+  messages[501] = "Not Implemented";
+  messages[502] = "Bad Gateway";
+  messages[503] = "Service Unavailable";
+  messages[504] = "Gateway Timeout";
   return messages;
 }

--- a/utils/Config.hpp
+++ b/utils/Config.hpp
@@ -17,6 +17,9 @@ class Config {
   // 상태코드 메시지
   static const std::map<int, std::string> statusMessages;
 
+  static std::string const defaultErrorPageBody(std::string const& code,
+                                                std::string const& message);
+
  private:
   static std::map<int, std::string> initializeStatusMessages(void);
 


### PR DESCRIPTION
## 구현 사항

### 기본 에러 페이지 구현
- `sendErrorPage` 함수 내부에 구현
- Config 파일에서 status-code와 reason-phrase 를 인자로 받아와 에러 페이지에 대한 html 파일 body를 생성
- Content-Length는 body의 size로 설정
- Content-Type은 `text/html`로 설정   
- 나중에 디자인이 마음에 안들면 리팩토링 필요.. (디자인은 너무 어려워요)

### Config.cpp에 상태 코드 메시지 추가
- 추가되어 있지 않았던 상태 코드에 대한 메시지 추가

### 실행 결과

<img width="800" alt="Screen Shot 2024-01-19 at 8 33 34 PM" src="https://github.com/wonyangs/webserv/assets/44529556/04c40443-310a-4411-85ee-e568af97af79">

<img width="800" alt="Screen Shot 2024-01-19 at 8 34 26 PM" src="https://github.com/wonyangs/webserv/assets/44529556/f744b5cd-6589-4b03-a25b-dc0d02b859fa">

### Issue
- close #35 