### PR TITLE
[Feat] ServerManager에 fd 관리 컨테이너 추가

### DIFF
--- a/server/ServerManager.hpp
+++ b/server/ServerManager.hpp
@@ -17,8 +17,10 @@ class ServerManager {
   int _serverFd;
   std::string _hostIp;
   int _port;
+
   std::vector<Server> _configs;
   std::map<int, Connection> _connections;
+  std::map<int, int> _managedFds;
 
  public:
   ServerManager(std::string hostIp, int port, std::vector<Server> configs);
@@ -35,6 +37,9 @@ class ServerManager {
   bool canHandleEvent(Event event) const;
   int getServerFd(void) const;
 
+  void addManagedFd(int managedFd, int ownerFd);
+  void removeManagedFd(int managedFd);
+
   Location const& getDefaultLocation(void);
   Location const& getLocation(std::string const& path, std::string const& host);
 
@@ -45,6 +50,9 @@ class ServerManager {
   void addConnection(int fd);
   void removeConnection(int fd);
   bool hasConnectionFd(int fd) const;
+
+  bool hasManagedFd(int fd) const;
+  void removeAllManagedFd(int managedFd);
 
   void handleServerEvent(void);
   void handleReadEvent(int eventFd);


### PR DESCRIPTION
### 변경 내용

- Connection 객체 내에서 새로운 fd를 열 경우 해당 fd를 ServerManager에서 관리해야 함
  - 파일 open, pipe 등

- (fd - 관리할 객체 fd) 관계로 묶어 이벤트가 들어오면 해당 fd를 관리할 객체를 찾아 처리
  - 이벤트 fd를 확인하여 해당 fd를 가지고 있는 Connection 객체의 fd를 알아냄
  - Connection 객체의 fd와 이벤트 fd를 통해 다시 작업 진행

- Connection 종료 시 해당하는 클라이언트 fd를 value로 가지는 key들을 모두 삭제

### issue

- 이벤트를 재설계해도 Connection을 찾는 문제는 개선되지 않을 것이라고 판단
- 추후에 필요한 경우 설계할 예정
- close: #40 
