### PR TITLE
[Feat] 서버 재시작 기능 구현

### DIFF
--- a/server/EventLoop.cpp
+++ b/server/EventLoop.cpp
@@ -82,6 +82,8 @@ void EventLoop::closeTimeoutConnections(void) {
   }
 }
 
+// 서버 시작
+// - 실패할 경우 성공할 때까지 재시도
 void EventLoop::start(void) {
   bool isStart = false;
   do {
@@ -93,12 +95,14 @@ void EventLoop::start(void) {
       }
       isStart = true;
     } catch (std::exception const& e) {
+      std::cout << "Server start retry..." << std::endl;
       std::cout << e.what() << std::endl;
     }
   } while (isStart == false);
 }
 
 // 서버 재시작
+// - 실패할 경우 성공할 때까지 재시도
 void EventLoop::restart(void) {
   bool isRestart = false;
   do {

--- a/server/EventLoop.cpp
+++ b/server/EventLoop.cpp
@@ -41,11 +41,7 @@ EventLoop::~EventLoop(void) {}
 // Public method
 
 void EventLoop::run(void) {
-  Kqueue::start();
-  for (ManagerMap::iterator it = _managers.begin(); it != _managers.end();
-       ++it) {
-    (it->second).run();
-  }
+  start();
 
   while (true) {
     try {
@@ -89,6 +85,22 @@ void EventLoop::closeTimeoutConnections(void) {
        ++it) {
     (it->second).manageTimeoutConnections();
   }
+}
+
+void EventLoop::start(void) {
+  bool isStart = false;
+  do {
+    try {
+      Kqueue::start();
+      for (ManagerMap::iterator it = _managers.begin(); it != _managers.end();
+           ++it) {
+        (it->second).run();
+      }
+      isStart = true;
+    } catch (std::exception const& e) {
+      std::cout << e.what() << std::endl;
+    }
+  } while (isStart == false);
 }
 
 // 서버 재시작

--- a/server/EventLoop.cpp
+++ b/server/EventLoop.cpp
@@ -67,12 +67,7 @@ void EventLoop::run(void) {
       }
     } catch (std::exception const& e) {
       std::cout << e.what() << std::endl;
-
-      bool restartStatus = false;
-      do {
-        std::cout << "Server restarting..." << std::endl;
-        restartStatus = restart();
-      } while (restartStatus == false);
+      restart();
     }
   }
 }
@@ -104,24 +99,27 @@ void EventLoop::start(void) {
 }
 
 // 서버 재시작
-bool EventLoop::restart(void) {
-  try {
-    for (ManagerMap::iterator it = _managers.begin(); it != _managers.end();
-         ++it) {
-      (it->second).clear();
-    }
-    Kqueue::close();
+void EventLoop::restart(void) {
+  bool isRestart = false;
+  do {
+    std::cout << "Server restarting..." << std::endl;
+    try {
+      for (ManagerMap::iterator it = _managers.begin(); it != _managers.end();
+           ++it) {
+        (it->second).clear();
+      }
+      Kqueue::close();
 
-    Kqueue::start();
-    for (ManagerMap::iterator it = _managers.begin(); it != _managers.end();
-         ++it) {
-      (it->second).run();
+      Kqueue::start();
+      for (ManagerMap::iterator it = _managers.begin(); it != _managers.end();
+           ++it) {
+        (it->second).run();
+      }
+      isRestart = true;
+    } catch (std::exception const& e) {
+      std::cout << e.what() << std::endl;
     }
-  } catch (std::exception const& e) {
-    std::cout << e.what() << std::endl;
-    return false;
-  }
-  return true;
+  } while (isRestart == false);
 }
 
 // debug

--- a/server/EventLoop.hpp
+++ b/server/EventLoop.hpp
@@ -26,6 +26,8 @@ class EventLoop {
   typedef std::map<int, ServerManager> ManagerMap;
 
   void closeTimeoutConnections(void);
+  bool restart(void);
+
   void printServerMap(const ServerMap& serverMap);  // debug
 
   EventLoop(void);

--- a/server/EventLoop.hpp
+++ b/server/EventLoop.hpp
@@ -26,6 +26,8 @@ class EventLoop {
   typedef std::map<int, ServerManager> ManagerMap;
 
   void closeTimeoutConnections(void);
+
+  void start(void);
   bool restart(void);
 
   void printServerMap(const ServerMap& serverMap);  // debug

--- a/server/EventLoop.hpp
+++ b/server/EventLoop.hpp
@@ -28,7 +28,7 @@ class EventLoop {
   void closeTimeoutConnections(void);
 
   void start(void);
-  bool restart(void);
+  void restart(void);
 
   void printServerMap(const ServerMap& serverMap);  // debug
 

--- a/server/ServerManager.cpp
+++ b/server/ServerManager.cpp
@@ -81,6 +81,7 @@ void ServerManager::clear(void) {
     (*it).second.close();
   }
   _connections.clear();
+  _managedFds.clear();
 }
 
 /**

--- a/server/ServerManager.cpp
+++ b/server/ServerManager.cpp
@@ -48,7 +48,7 @@ ServerManager& ServerManager::operator=(ServerManager const& manager) {
 
 // 서버 소켓 할당 및 listening 시작
 // - 서버 시작 실패 시 예외 발생
-void ServerManager::runServer(void) {
+void ServerManager::init(void) {
   try {
     _serverFd = Socket::socket();
 
@@ -56,14 +56,25 @@ void ServerManager::runServer(void) {
     Socket::setNonBlocking(_serverFd);
     Socket::bind(_serverFd, _hostIp, _port);
     Socket::listen(_serverFd, 3);
-
-    Kqueue::addReadEvent(_serverFd);
   } catch (const std::exception& e) {
     if (_serverFd != -1) {
       close(_serverFd);
     }
     throw;
   }
+}
+
+// 서버 fd를 kqueue에 추가하고 동작 시작
+// - kqueue에 이벤트 추가를 실패한 경우 예외 발생
+void ServerManager::run(void) { Kqueue::addReadEvent(_serverFd); }
+
+// 서버가 관리하는 모든 client를 제거
+void ServerManager::clear(void) {
+  for (ConnectionMap::iterator it = _connections.begin();
+       it != _connections.end(); ++it) {
+    (*it).second.close();
+  }
+  _connections.clear();
 }
 
 /**

--- a/server/ServerManager.hpp
+++ b/server/ServerManager.hpp
@@ -27,7 +27,9 @@ class ServerManager {
 
   ServerManager& operator=(ServerManager const& manager);
 
-  void runServer(void);
+  void init(void);
+  void run(void);
+  void clear(void);
 
   void handleEvent(Event event);
   void manageTimeoutConnections(void);


### PR DESCRIPTION
### ServerManager

- runServer 메서드를 init과 run으로 분리
  - init 메서드: 서버 소켓을 여는 부분
  - run 메서드: kqueue에 서버 소켓 이벤트를 추가하는 부분
- close 메서드 추가
  - 클라이언트 fd를 모두 닫음 (서버 소켓은 열려있어야 하기 때문에 닫지 않음)
  - 외부에서 kqueue가 close되면 모든 이벤트가 삭제되기 때문에 이벤트 삭제는 진행하지 않음

### EventLoop

- eventloop가 시작되기 전 서버 소켓을 모두 열음
  - 서버가 정상 작동된 시점은 서버 소켓이 모두 열려있음이 보장됨
- eventloop가 실행될 때 kqueue을 할당하고 모든 이벤트를 등록함
- 서버에서 예상치 못한 예외가 발생할 시 restart 메서드가 실행됨
  - restart 메서드는 모든 클라이언트 fd와 kqueue를 닫고, kqueue를 다시 시작함
  - restart 메서드가 예외 없이 성공할 때까지 재시작을 반복함
 
### 관련 이미지
<img width="400" alt="image" src="https://github.com/wonyangs/webserv/assets/43935708/d48d8d6e-fc37-411d-8f89-f139b93bf272">

- 코드에서 강제로 예외를 1회 throw하자 서버가 재시작됨
- 재시작 이후에도 요청을 정상적으로 받음