### PR TITLE
[Feat] AResponseBuilder 설계 및 ErrorBuilder 기본 에러 페이지 반환

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,9 @@ SRCS		= config/Server.cpp \
 			  http/Request.cpp \
 			  http/RequestParser.cpp \
 			  http/Response.cpp \
+			  http/AResponseBuilder.cpp \
 			  main.cpp
+				
 
 OBJS		= $(SRCS:%.cpp=%.o)
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SRCS		= config/Server.cpp \
 			  http/RequestParser.cpp \
 			  http/Response.cpp \
 			  http/AResponseBuilder.cpp \
+			  http/ErrorBuilder.cpp \
 			  main.cpp
 				
 

--- a/config/Location.cpp
+++ b/config/Location.cpp
@@ -4,6 +4,8 @@
 
 // Constructor & Destructor
 
+Location::Location(void){};
+
 Location::Location(std::string const& uri, std::string const& rootPath,
                    std::string const& indexFile)
     : _uri(uri),

--- a/config/Location.hpp
+++ b/config/Location.hpp
@@ -23,6 +23,7 @@ class Location {
   std::string _redirectUri;
 
  public:
+  Location(void);
   Location(std::string const& uri, std::string const& rootPath,
            std::string const& indexFile);
   Location(Location const& location);
@@ -54,8 +55,6 @@ class Location {
 
   bool _hasAllowMethodField;
   bool _hasRedirectField;
-
-  Location(void);
 };
 
 #endif

--- a/http/AResponseBuilder.cpp
+++ b/http/AResponseBuilder.cpp
@@ -26,6 +26,12 @@ AResponseBuilder& AResponseBuilder::operator=(AResponseBuilder const& builder) {
 }
 
 /**
+ * Protected method - setter
+ */
+
+void AResponseBuilder::setType(EBuilderType const& type) { _type = type; }
+
+/**
  * Public method
  */
 

--- a/http/AResponseBuilder.cpp
+++ b/http/AResponseBuilder.cpp
@@ -4,10 +4,12 @@
  * Constructor & Destructor
  */
 
-AResponseBuilder::AResponseBuilder(EBuilderType const& type) : _type(type) {}
+AResponseBuilder::AResponseBuilder(EBuilderType const& type,
+                                   Request const& request)
+    : _request(request), _type(type) {}
 
 AResponseBuilder::AResponseBuilder(AResponseBuilder const& builder)
-    : _type(builder._type) {}
+    : _request(builder._request), _type(builder._type) {}
 
 AResponseBuilder::~AResponseBuilder(void) {}
 
@@ -16,14 +18,19 @@ AResponseBuilder::~AResponseBuilder(void) {}
  */
 
 AResponseBuilder& AResponseBuilder::operator=(AResponseBuilder const& builder) {
-  _type = builder._type;
-  _response = builder._response;
+  if (this != &builder) {
+    _type = builder._type;
+    _response = builder._response;
+  }
+  return *this;
 }
 
 /**
  * Public method
  */
 
-EBuilderType const& AResponseBuilder::getType(void) const { return _type; }
+AResponseBuilder::EBuilderType const& AResponseBuilder::getType(void) const {
+  return _type;
+}
 
 Response const& AResponseBuilder::getResponse(void) const { return _response; }

--- a/http/AResponseBuilder.cpp
+++ b/http/AResponseBuilder.cpp
@@ -1,0 +1,29 @@
+#include "AResponseBuilder.hpp"
+
+/**
+ * Constructor & Destructor
+ */
+
+AResponseBuilder::AResponseBuilder(EBuilderType const& type) : _type(type) {}
+
+AResponseBuilder::AResponseBuilder(AResponseBuilder const& builder)
+    : _type(builder._type) {}
+
+AResponseBuilder::~AResponseBuilder(void) {}
+
+/**
+ * Operator Overloading
+ */
+
+AResponseBuilder& AResponseBuilder::operator=(AResponseBuilder const& builder) {
+  _type = builder._type;
+  _response = builder._response;
+}
+
+/**
+ * Public method
+ */
+
+EBuilderType const& AResponseBuilder::getType(void) const { return _type; }
+
+Response const& AResponseBuilder::getResponse(void) const { return _response; }

--- a/http/AResponseBuilder.hpp
+++ b/http/AResponseBuilder.hpp
@@ -1,12 +1,17 @@
 #ifndef __A_RESPONSE_BUILDER_HPP__
 #define __A_RESPONSE_BUILDER_HPP__
 
+#include "Request.hpp"
 #include "Response.hpp"
 
 class AResponseBuilder {
+ protected:
+  enum EBuilderType { ERROR };
+  Request const& _request;
+  Response _response;
+
  private:
   EBuilderType _type;
-  Response _response;
 
  public:
   EBuilderType const& getType(void) const;
@@ -16,9 +21,7 @@ class AResponseBuilder {
   virtual void close(void) = 0;
 
  protected:
-  enum EBuilderType = {ERROR};
-
-  AResponseBuilder(EBuilderType const& type);
+  AResponseBuilder(EBuilderType const& type, Request const& request);
   AResponseBuilder(AResponseBuilder const& builder);
   ~AResponseBuilder(void);
 

--- a/http/AResponseBuilder.hpp
+++ b/http/AResponseBuilder.hpp
@@ -27,6 +27,8 @@ class AResponseBuilder {
 
   AResponseBuilder& operator=(AResponseBuilder const& builder);
 
+  void setType(EBuilderType const& type);
+
  private:
   AResponseBuilder(void);
 };

--- a/http/AResponseBuilder.hpp
+++ b/http/AResponseBuilder.hpp
@@ -1,0 +1,31 @@
+#ifndef __A_RESPONSE_BUILDER_HPP__
+#define __A_RESPONSE_BUILDER_HPP__
+
+#include "Response.hpp"
+
+class AResponseBuilder {
+ private:
+  EBuilderType _type;
+  Response _response;
+
+ public:
+  EBuilderType const& getType(void) const;
+  Response const& getResponse(void) const;
+
+  virtual void build(void) = 0;
+  virtual void close(void) = 0;
+
+ protected:
+  enum EBuilderType = {ERROR};
+
+  AResponseBuilder(EBuilderType const& type);
+  AResponseBuilder(AResponseBuilder const& builder);
+  ~AResponseBuilder(void);
+
+  AResponseBuilder& operator=(AResponseBuilder const& builder);
+
+ private:
+  AResponseBuilder(void);
+};
+
+#endif

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -32,13 +32,14 @@ ErrorBuilder& ErrorBuilder::operator=(ErrorBuilder const& builder) {
  */
 
 void ErrorBuilder::build(void) {
-  Location const& location = _request.getLocation();
+  generateDefaultPage();
 
-  if (location.hasErrorPage(_statusCode)) {
-    readStatusCodeFile();
-  } else {
-    generateDefaultPage();
-  }
+  // Location const& location = _request.getLocation();
+  // if (location.hasErrorPage(_statusCode)) {
+  //   readStatusCodeFile();
+  // } else {
+  //   generateDefaultPage();
+  // }
 }
 
 void ErrorBuilder::close(void) {}
@@ -51,4 +52,22 @@ void ErrorBuilder::readStatusCodeFile(void) {
   // open file
 }
 
-void ErrorBuilder::generateDefaultPage(void) {}
+// Connection은 request Header 정보 보고 변경되어야 함
+void ErrorBuilder::generateDefaultPage(void) {
+  // HTTP 응답 생성
+  std::stringstream ss;
+
+  std::string const& body = Config::defaultErrorPageBody(_statusCode);
+  ss << body.size();
+
+  _response.setHttpVersion("HTTP/1.1");
+  _response.setStatusCode(_statusCode);
+
+  _response.addHeader("Content-Type", "text/html");
+  _response.addHeader("Content-Length", ss.str());
+  _response.addHeader("Connection", "keep-alive");
+
+  _response.appendBody(body);
+
+  _response.makeResponseContent();
+}

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -31,6 +31,25 @@ ErrorBuilder& ErrorBuilder::operator=(ErrorBuilder const& builder) {
  * Public method
  */
 
-void ErrorBuilder::build(void) {}
+void ErrorBuilder::build(void) {
+  Location const& location = _request.getLocation();
+
+  if (location.hasErrorPage(_statusCode)) {
+    readStatusCodeFile();
+  } else {
+    generateDefaultPage();
+  }
+}
 
 void ErrorBuilder::close(void) {}
+
+/**
+ * Public method
+ */
+
+void ErrorBuilder::readStatusCodeFile(void) {
+  // open file
+  
+}
+
+void ErrorBuilder::generateDefaultPage(void) {}

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -20,7 +20,7 @@ ErrorBuilder::~ErrorBuilder(void) {}
 
 ErrorBuilder& ErrorBuilder::operator=(ErrorBuilder const& builder) {
   if (this != &builder) {
-    _type = builder._type;
+    setType(builder.getType());
     _response = builder._response;
     _statusCode = builder._statusCode;
   }
@@ -49,7 +49,6 @@ void ErrorBuilder::close(void) {}
 
 void ErrorBuilder::readStatusCodeFile(void) {
   // open file
-  
 }
 
 void ErrorBuilder::generateDefaultPage(void) {}

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -1,0 +1,36 @@
+#include "ErrorBuilder.hpp"
+
+/**
+ * Constructor & Destructor
+ */
+
+ErrorBuilder::ErrorBuilder(Request const& request, int statusCode)
+    : AResponseBuilder(ERROR, request), _statusCode(statusCode) {}
+
+ErrorBuilder::ErrorBuilder(ErrorBuilder const& builder)
+    : AResponseBuilder(builder) {
+  _statusCode = builder._statusCode;
+}
+
+ErrorBuilder::~ErrorBuilder(void) {}
+
+/**
+ * Operator Overloading
+ */
+
+ErrorBuilder& ErrorBuilder::operator=(ErrorBuilder const& builder) {
+  if (this != &builder) {
+    _type = builder._type;
+    _response = builder._response;
+    _statusCode = builder._statusCode;
+  }
+  return *this;
+}
+
+/**
+ * Public method
+ */
+
+void ErrorBuilder::build(void) {}
+
+void ErrorBuilder::close(void) {}

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -55,16 +55,14 @@ void ErrorBuilder::readStatusCodeFile(void) {
 // Connection은 request Header 정보 보고 변경되어야 함
 void ErrorBuilder::generateDefaultPage(void) {
   // HTTP 응답 생성
-  std::stringstream ss;
 
   std::string const& body = Config::defaultErrorPageBody(_statusCode);
-  ss << body.size();
 
   _response.setHttpVersion("HTTP/1.1");
   _response.setStatusCode(_statusCode);
 
   _response.addHeader("Content-Type", "text/html");
-  _response.addHeader("Content-Length", ss.str());
+  _response.addHeader("Content-Length", Util::itos(body.size()));
   _response.addHeader("Connection", "keep-alive");
 
   _response.appendBody(body);

--- a/http/ErrorBuilder.hpp
+++ b/http/ErrorBuilder.hpp
@@ -1,6 +1,7 @@
 #ifndef __ERROR_BUILDER_HPP__
 #define __ERROR_BUILDER_HPP__
 
+#include "../utils/Util.hpp"
 #include "AResponseBuilder.hpp"
 
 class ErrorBuilder : public AResponseBuilder {

--- a/http/ErrorBuilder.hpp
+++ b/http/ErrorBuilder.hpp
@@ -19,6 +19,9 @@ class ErrorBuilder : public AResponseBuilder {
 
  private:
   ErrorBuilder(void);
+
+  void readStatusCodeFile(void);
+  void generateDefaultPage(void);
 };
 
 #endif

--- a/http/ErrorBuilder.hpp
+++ b/http/ErrorBuilder.hpp
@@ -1,0 +1,24 @@
+#ifndef __ERROR_BUILDER_HPP__
+#define __ERROR_BUILDER_HPP__
+
+#include "AResponseBuilder.hpp"
+
+class ErrorBuilder : public AResponseBuilder {
+ private:
+  int _statusCode;
+
+ public:
+  ErrorBuilder(Request const& request, int statusCode);
+  ErrorBuilder(ErrorBuilder const& builder);
+  ~ErrorBuilder(void);
+
+  ErrorBuilder& operator=(ErrorBuilder const& builder);
+
+  virtual void build(void);
+  virtual void close(void);
+
+ private:
+  ErrorBuilder(void);
+};
+
+#endif

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -2,7 +2,7 @@
 
 // Constructor & Destructor
 
-Request::Request(void) : _method(HTTP_NONE) {}
+Request::Request(void) : _method(HTTP_NONE), _locationFlag(false) {}
 
 Request::Request(Request const& request) { *this = request; }
 
@@ -18,6 +18,9 @@ Request& Request::operator=(Request const& request) {
     _httpVersion = request._httpVersion;
     _header = request._header;
     _body = request._body;
+
+    _location = request._location;
+    _locationFlag = request._locationFlag;
   }
   return *this;
 }
@@ -45,6 +48,7 @@ void Request::print() const {
   }
 
   std::cout << "Body: " << _body << std::endl;
+  std::cout << "Location uri: " << _location.getUri() << std::endl;
 }
 
 // Public Method - getter
@@ -62,6 +66,8 @@ std::map<std::string, std::vector<std::string> > const& Request::getHeader(
   return _header;
 }
 
+Location const& Request::getLocation(void) const { return _location; }
+
 std::string const& Request::getBody(void) const { return _body; }
 
 std::vector<std::string> const& Request::getHeaderFieldValues(
@@ -74,6 +80,13 @@ std::vector<std::string> const& Request::getHeaderFieldValues(
   std::map<std::string, std::vector<std::string> >::const_iterator it =
       _header.find(fieldName);
   return it->second;
+}
+
+// Public Method - setter
+
+void Request::setLocation(Location const& location) {
+  _location = location;
+  _locationFlag = true;
 }
 
 // Public Method
@@ -141,6 +154,7 @@ void Request::clear() {
   _httpVersion.clear();
   _header.clear();
   _body.clear();
+  _locationFlag = false;
 }
 
 // Private Method - setter

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <vector>
 
+#include "../config/Location.hpp"
 #include "../utils/Config.hpp"
 #include "../utils/Enum.hpp"
 #include "../utils/StatusException.hpp"
@@ -19,6 +20,9 @@ class Request {
   std::map<std::string, std::vector<std::string> > _header;
   std::string _body;
 
+  bool _locationFlag;
+  Location _location;
+
  public:
   Request(void);
   Request(Request const& request);
@@ -32,9 +36,12 @@ class Request {
   std::string const& getHttpVersion(void) const;
   std::map<std::string, std::vector<std::string> > const& getHeader(void) const;
   std::string const& getBody(void) const;
+  Location const& getLocation(void) const;
 
   std::vector<std::string> const& getHeaderFieldValues(
       std::string const& fieldName) const;
+
+  void setLocation(Location const& location);
 
   void print(void) const;  // debug
 

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -35,6 +35,12 @@ enum EParsingStatus RequestParser::getParsingStatus() const { return _status; }
 
 Request const& RequestParser::getRequest() const { return _request; }
 
+// Public Method - setter
+
+void RequestParser::setRequestLocation(Location const& location) {
+  _request.setLocation(location);
+}
+
 // Public Method
 
 #include <iostream>

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -55,6 +55,8 @@ class RequestParser {
   enum EParsingStatus getParsingStatus(void) const;
   Request const& getRequest(void) const;
 
+  void setRequestLocation(Location const& location);
+
   void parse(u_int8_t const* buffer, ssize_t bytesRead);
   void clear();
 

--- a/http/Response.cpp
+++ b/http/Response.cpp
@@ -62,11 +62,32 @@ std::string const& Response::getBody(void) const { return _body; }
 
 // Public Method - setter
 
+void Response::setResponseContent(void) {
+  std::string const crlf = "\r\n";
+
+  std::stringstream ss;
+
+  ss << _httpVersion << " " << _statusCode << " "
+     << findStatusMessage(_statusCode) << crlf;
+
+  for (std::map<std::string, std::string>::const_iterator it = _header.begin();
+       it != _header.end(); ++it) {
+    ss << it->first << ": " << it->second << crlf;
+  }
+  ss << crlf;
+  ss << _body;
+
+  _responseContent = ss.str();
+  _startIndex = 0;
+}
+
 void Response::setHttpVersion(std::string const& httpVersion) {
   _httpVersion = httpVersion;
 }
 
-void Response::setMethod(int const& statusCode) { _statusCode = statusCode; }
+void Response::setStatusCode(int const& statusCode) {
+  _statusCode = statusCode;
+}
 
 // Public Method
 
@@ -93,6 +114,23 @@ void Response::clear(void) {
   _header.clear();
   _body.clear();
 }
+
+// 상태 코드에 해당하는 메시지 찾기
+// - 정의되지 않은 코드일 경우 예외 발생
+std::string const& Response::findStatusMessage(int code) {
+  std::map<int, std::string>::const_iterator it =
+      Config::statusMessages.find(code);
+
+  if (it == Config::statusMessages.end()) {
+    throw std::runtime_error(
+        "[5001] Response: findStatusMessage - status message does not exist: " +
+        std::to_string(code));
+  }
+
+  return it->second;
+}
+
+// Private Method
 
 // 해당 헤더 field-name의 존재를 확인하는 함수
 bool Response::isHeaderFieldNameExists(std::string const& fieldName) const {

--- a/http/Response.cpp
+++ b/http/Response.cpp
@@ -60,15 +60,17 @@ std::map<std::string, std::string> const& Response::getHeader(void) const {
 
 std::string const& Response::getBody(void) const { return _body; }
 
+std::string const& Response::toString(void) const { return _responseContent; }
+
 // Public Method - setter
 
-void Response::setResponseContent(void) {
+void Response::makeResponseContent(void) {
   std::string const crlf = "\r\n";
 
   std::stringstream ss;
 
   ss << _httpVersion << " " << _statusCode << " "
-     << findStatusMessage(_statusCode) << crlf;
+     << Config::findStatusMessage(_statusCode) << crlf;
 
   for (std::map<std::string, std::string>::const_iterator it = _header.begin();
        it != _header.end(); ++it) {
@@ -113,21 +115,6 @@ void Response::clear(void) {
   _statusCode = -1;
   _header.clear();
   _body.clear();
-}
-
-// 상태 코드에 해당하는 메시지 찾기
-// - 정의되지 않은 코드일 경우 예외 발생
-std::string const& Response::findStatusMessage(int code) {
-  std::map<int, std::string>::const_iterator it =
-      Config::statusMessages.find(code);
-
-  if (it == Config::statusMessages.end()) {
-    throw std::runtime_error(
-        "[5001] Response: findStatusMessage - status message does not exist: " +
-        std::to_string(code));
-  }
-
-  return it->second;
 }
 
 // Private Method

--- a/http/Response.hpp
+++ b/http/Response.hpp
@@ -34,8 +34,9 @@ class Response {
   int const& getStatusCode(void) const;
   std::map<std::string, std::string> const& getHeader(void) const;
   std::string const& getBody(void) const;
+  std::string const& toString(void) const;
 
-  void setResponseContent(void);
+  void makeResponseContent(void);
 
   void setHttpVersion(std::string const& httpVersion);
   void setStatusCode(int const& statusCode);
@@ -44,8 +45,6 @@ class Response {
   void appendBody(std::string const& body);
 
   void clear(void);
-
-  std::string const& findStatusMessage(int code);
 
  private:
   bool isHeaderFieldNameExists(std::string const& fieldName) const;

--- a/http/Response.hpp
+++ b/http/Response.hpp
@@ -3,6 +3,7 @@
 
 #include <exception>
 #include <map>
+#include <sstream>
 #include <string>
 
 #include "../utils/Config.hpp"
@@ -34,13 +35,17 @@ class Response {
   std::map<std::string, std::string> const& getHeader(void) const;
   std::string const& getBody(void) const;
 
+  void setResponseContent(void);
+
   void setHttpVersion(std::string const& httpVersion);
-  void setMethod(int const& statusCode);
+  void setStatusCode(int const& statusCode);
 
   void addHeader(std::string const& fieldName, std::string const& fieldValue);
   void appendBody(std::string const& body);
 
   void clear(void);
+
+  std::string const& findStatusMessage(int code);
 
  private:
   bool isHeaderFieldNameExists(std::string const& fieldName) const;

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -164,8 +164,7 @@ void Connection::sendErrorPage(int code) {
   std::string codeString = std::to_string(code);
 
   // HTTP 응답 생성
-  std::string const& body =
-      Config::defaultErrorPageBody(codeString, it->second);
+  std::string const& body = Config::defaultErrorPageBody(code, it->second);
 
   std::string response =
       "HTTP/1.1 " + codeString + " " + it->second + "\n" +

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -18,11 +18,10 @@ Connection::Connection(int fd, ServerManager& manager)
       _lastCallTime(std::time(0)),
       _status(ON_WAIT),
       _requestParser(),
-      _location(manager.getDefaultLocation()),
       _manager(manager) {}
 
 Connection::Connection(Connection const& connection)
-    : _location(connection._location), _manager(connection._manager) {
+    : _manager(connection._manager) {
   *this = connection;
 }
 
@@ -91,8 +90,7 @@ void Connection::parseRequest(u_int8_t const* buffer, ssize_t bytesRead) {
     if (_requestParser.getParsingStatus() == HEADER_FIELD_END) {
       // Location 블록 할당
       Request const& request = _requestParser.getRequest();
-      setLocation(request);
-      // _requestParser.setLocation(location);
+      setRequestParserLocation(request);
       // 다시 파싱
       _requestParser.parse(buffer, 0);
     }
@@ -215,11 +213,12 @@ long Connection::getElapsedTime(void) const {
  */
 
 // path와 host 정보를 가지고 알맞은 location 블럭을 할당
-void Connection::setLocation(Request const& request) {
+void Connection::setRequestParserLocation(Request const& request) {
   std::string const& path = request.getPath();
   std::string const& host = request.getHeaderFieldValues("host").front();
 
-  _location = _manager.getLocation(path, host);
+  Location const& location = _manager.getLocation(path, host);
+  _requestParser.setRequestLocation(location);
 }
 
 // 마지막으로 호출된 시간 업데이트

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -21,7 +21,6 @@ class Connection {
   enum EStatus _status;
 
   RequestParser _requestParser;
-  Location _location;
 
  public:
   Connection(int fd, ServerManager& manager);
@@ -48,7 +47,7 @@ class Connection {
   ServerManager& _manager;
 
   void parseRequest(u_int8_t const* buffer, ssize_t bytesRead);
-  void setLocation(Request const& request);
+  void setRequestParserLocation(Request const& request);
 
   void updateLastCallTime(void);
   void setStatus(EStatus status);

--- a/utils/Config.cpp
+++ b/utils/Config.cpp
@@ -42,12 +42,9 @@ std::string const& Config::findStatusMessage(int code) {
       Config::statusMessages.find(code);
 
   if (it == Config::statusMessages.end()) {
-    std::stringstream ss;
-
-    ss << code;
     throw std::runtime_error(
         "[6000] Config: findStatusMessage - status message does not exist: " +
-        ss.str());
+        Util::itos(code));
   }
 
   return it->second;

--- a/utils/Config.cpp
+++ b/utils/Config.cpp
@@ -35,9 +35,27 @@ std::map<int, std::string> Config::initializeStatusMessages(void) {
   return messages;
 }
 
-std::string const Config::defaultErrorPageBody(int code,
-                                               std::string const& message) {
+// 상태 코드에 해당하는 메시지 찾기
+// - 정의되지 않은 코드일 경우 예외 발생
+std::string const& Config::findStatusMessage(int code) {
+  std::map<int, std::string>::const_iterator it =
+      Config::statusMessages.find(code);
+
+  if (it == Config::statusMessages.end()) {
+    std::stringstream ss;
+
+    ss << code;
+    throw std::runtime_error(
+        "[6000] Config: findStatusMessage - status message does not exist: " +
+        ss.str());
+  }
+
+  return it->second;
+}
+
+std::string const Config::defaultErrorPageBody(int code) {
   std::stringstream ss;
+  std::string const& message = Config::findStatusMessage(code);
 
   ss << "<!DOCTYPE html> <html> <head> <title>ERROR</title> <style> "
         "@font-face { font-family: 'WarhavenB'; src: "
@@ -48,7 +66,8 @@ std::string const Config::defaultErrorPageBody(int code,
         "align-items: center; text-align: center; } .container { margin: "
         "50px auto; animation: shake 0.5s cubic-bezier(.36,.07,.19,.97) both; "
         "transform: translate3d(0, 0, 0); backface-visibility: hidden; "
-        "perspective: 1000px; } .error { font-size: 100px; color: #313438bd; } "
+        "perspective: 1000px; } .error { font-size: 100px; color: #313438bd; "
+        "} "
         "@keyframes shake { 10%, 90% { transform: translate3d(-1px, 0, 0);} "
         "20%, 80% { transform: translate3d(2px, 0, 0); } 30%, 50%, 70% {  "
         "transform: translate3d(-4px, 0, 0); } 40%, 60% {  transform: "

--- a/utils/Config.cpp
+++ b/utils/Config.cpp
@@ -35,26 +35,29 @@ std::map<int, std::string> Config::initializeStatusMessages(void) {
   return messages;
 }
 
-std::string const Config::defaultErrorPageBody(std::string const& code,
+std::string const Config::defaultErrorPageBody(int code,
                                                std::string const& message) {
-  std::string const body =
-      "<!DOCTYPE html> <html> <head> <title>ERROR</title> <style> "
-      "@font-face { font-family: 'WarhavenB'; src: "
-      "url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2312-1@1.1/"
-      "WarhavenB.woff2') format('woff2'); font-weight: 700; font-style: "
-      "normal; } body {font-family: 'WarhavenB', Arial, sans-serif; "
-      "background-color: #d7ddcd; margin: 0; padding: 0; display: flex; "
-      "align-items: center; text-align: center; } .container { margin: "
-      "50px auto; animation: shake 0.5s cubic-bezier(.36,.07,.19,.97) both; "
-      "transform: translate3d(0, 0, 0); backface-visibility: hidden; "
-      "perspective: 1000px; } .error { font-size: 100px; color: #313438bd; } "
-      "@keyframes shake { 10%, 90% { transform: translate3d(-1px, 0, 0);} "
-      "20%, 80% { transform: translate3d(2px, 0, 0); } 30%, 50%, 70% {  "
-      "transform: translate3d(-4px, 0, 0); } 40%, 60% {  transform: "
-      "translate3d(4px, 0, 0);}} </style> </head> <body> <div class= "
-      "\"container \"> <h1 class=\"error\">" +
-      code + " " + message + "</h1> <img src=\" https://http.cat/" + code +
-      "\"alt=\"Error Image\" class=\"error-image\"> </div> </body>\n\n";
+  std::stringstream ss;
 
-  return body;
+  ss << "<!DOCTYPE html> <html> <head> <title>ERROR</title> <style> "
+        "@font-face { font-family: 'WarhavenB'; src: "
+        "url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2312-1@1.1/"
+        "WarhavenB.woff2') format('woff2'); font-weight: 700; font-style: "
+        "normal; } body {font-family: 'WarhavenB', Arial, sans-serif; "
+        "background-color: #d7ddcd; margin: 0; padding: 0; display: flex; "
+        "align-items: center; text-align: center; } .container { margin: "
+        "50px auto; animation: shake 0.5s cubic-bezier(.36,.07,.19,.97) both; "
+        "transform: translate3d(0, 0, 0); backface-visibility: hidden; "
+        "perspective: 1000px; } .error { font-size: 100px; color: #313438bd; } "
+        "@keyframes shake { 10%, 90% { transform: translate3d(-1px, 0, 0);} "
+        "20%, 80% { transform: translate3d(2px, 0, 0); } 30%, 50%, 70% {  "
+        "transform: translate3d(-4px, 0, 0); } 40%, 60% {  transform: "
+        "translate3d(4px, 0, 0);}} </style> </head> <body> <div class= "
+        "\"container \"> <h1 class=\"error\">";
+
+  ss << code << " " << message << "</h1>";
+  ss << " <img src=\" https://http.cat/" << code
+     << "\"alt=\"Error Image\" class=\"error-image\"> </div> </body>\n\n";
+
+  return ss.str();
 }

--- a/utils/Config.hpp
+++ b/utils/Config.hpp
@@ -18,8 +18,8 @@ class Config {
   // 상태코드 메시지
   static const std::map<int, std::string> statusMessages;
 
-  static std::string const defaultErrorPageBody(int code,
-                                                std::string const& message);
+  static std::string const& findStatusMessage(int code);
+  static std::string const defaultErrorPageBody(int code);
 
  private:
   static std::map<int, std::string> initializeStatusMessages(void);

--- a/utils/Config.hpp
+++ b/utils/Config.hpp
@@ -2,6 +2,7 @@
 #define __CONFIG_HPP__
 
 #include <map>
+#include <sstream>
 #include <string>
 
 // 서버가 사용하는 설정들을 정의해 둔 static 클래스
@@ -17,7 +18,7 @@ class Config {
   // 상태코드 메시지
   static const std::map<int, std::string> statusMessages;
 
-  static std::string const defaultErrorPageBody(std::string const& code,
+  static std::string const defaultErrorPageBody(int code,
                                                 std::string const& message);
 
  private:

--- a/utils/Config.hpp
+++ b/utils/Config.hpp
@@ -5,6 +5,8 @@
 #include <sstream>
 #include <string>
 
+#include "Util.hpp"
+
 // 서버가 사용하는 설정들을 정의해 둔 static 클래스
 class Config {
  public:

--- a/utils/Util.cpp
+++ b/utils/Util.cpp
@@ -1,0 +1,7 @@
+#include "Util.hpp"
+
+std::string const Util::itos(int n) {
+  std::stringstream ss;
+  ss << n;
+  return ss.str();
+}

--- a/utils/Util.hpp
+++ b/utils/Util.hpp
@@ -1,0 +1,18 @@
+#ifndef __UTIL_HPP__
+#define __UTIL_HPP__
+
+#include <sstream>
+#include <string>
+
+class Util {
+ public:
+  static std::string const itos(int n);
+
+ private:
+  Util(void);
+  Util(Util const& util);
+  ~Util(void);
+  Util& operator=(Util const& util);
+};
+
+#endif


### PR DESCRIPTION
## 구현 사항

### Request 객체에 _location 멤버 변수 추가

- 이전에는 Connection 객체에서 관리
- 파싱 중 Request에 대한 Location이 할당됨
- 할당되기 이전에 대한 판별은 location flag로 확인 가능
- Location 기본 생성자 구현

### AResponseBuilder 추상 클래스 설계 및 기초 구현
- request와 response 멤버 변수를 포함
- EBuilderType은 AResponseBuilder를 상속받는 클래스 중 하나를 표현
- 생성자에서 request와 EBuilderType 초기화
- 가상 함수
  - `build()`: 응답 생성을 담당
    - 추후 이벤트 상태, 커넥션 상태를 인자로 받을 예정
  - `close()`: 커넥션이 닫힐 때 가지고 있는 fd를 닫아주는 역할 
```c++
class AResponseBuilder {
 protected:
  enum EBuilderType { ERROR }; // 추후 추가 예정
  Request const& _request;
  Response _response;

 private:
  EBuilderType _type;

 public:
  EBuilderType const& getType(void) const;
  Response const& getResponse(void) const;

  virtual void build(void) = 0;
  virtual void close(void) = 0;
  ...
}
``` 

### Response 객체 함수 추가 구현

```c++
std::string const& toString(void) const;
void makeResponseContent(void);
``` 
- ResponseBuilder에서 필요한 정보를 response 객체에 저장한 후 `makeResponseContent` 함수 호출 시 실제로 응답될 문자열을 만들어 `_responseContent`에 저장
- 이후 소켓에서 WRITE를 할 때 toString 함수를 호출해 _responseContent 결과를 반환받을 수 있음 (setResponseContent와 동일한 역할)

### ErrorBuilder 클래스 설계
- AResponseBuilder를 상속받음
- statusCode 멤버 변수 선언
- location에 상태코드에 대한 에러 페이지가 정의되어 있다면 `readStatusCodeFile()` 호출
- 아니라면 `generateDefaultPage()` 호출
  - 현재는 구현중이라 `generateDefaultPage()`를 호출하도록 되어있음
- `generateDefaultPage` 함수 구현
  - Config 파일에 구현한 `defaultErrorPageBody(int code)`를 활용하여 body 저장 및 response에 필요한 정보 저장
- `sendErrorPage` 함수에서 확인차 ErrorBuilder 객체를 생성해 사용하도록 코드 수정

### Util 클래스 생성
- 반복적으로 사용하는 유틸 함수들을 저장할 클래스 생성
- std::string을 int로 형변환하는 stoi 함수 구현

## To-do!
- 응답 생성 시 필요한 헤더를 Location에서 정보 확인 후 추가하는 부분 필요
- 아직 구현되지 않은 함수 모두 구현하기