### PR TITLE
[Feat] 전체적인 응답 생성 및 전송 흐름 설계 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SRCS		= config/Server.cpp \
 			  config/Location.cpp \
 			  utils/StatusException.cpp \
 			  utils/Config.cpp \
+				utils/Util.cpp \
 			  core/Kqueue.cpp \
 			  core/Event.cpp \
 			  core/Socket.cpp \

--- a/core/Kqueue.cpp
+++ b/core/Kqueue.cpp
@@ -25,6 +25,7 @@ void Kqueue::close(void) {
   if (_fd != -1) {
     ::close(_fd);
   }
+  _events.clear();
 }
 
 // Public method
@@ -52,7 +53,7 @@ void Kqueue::addWriteEvent(int fd) {
     throw std::runtime_error("[3002] Kqueue: addWriteEvent - event add failed");
   }
 
-  updateEventStatus(fd, READ_EVENT, ADD);
+  updateEventStatus(fd, WRITE_EVENT, ADD);
 }
 
 // READ 이벤트 제거

--- a/http/AResponseBuilder.cpp
+++ b/http/AResponseBuilder.cpp
@@ -4,8 +4,6 @@
  * Constructor & Destructor
  */
 
-AResponseBuilder::AResponseBuilder(void) : _isDone(false), _type(NONE) {}
-
 AResponseBuilder::AResponseBuilder(EBuilderType const& type,
                                    Request const& request)
     : _isDone(false), _request(request), _type(type) {}
@@ -35,9 +33,6 @@ AResponseBuilder& AResponseBuilder::operator=(AResponseBuilder const& builder) {
 /**
  * Public method
  */
-
-void AResponseBuilder::build(void) {}
-void AResponseBuilder::close(void) {}
 
 AResponseBuilder::EBuilderType const& AResponseBuilder::getType(void) const {
   return _type;

--- a/http/AResponseBuilder.cpp
+++ b/http/AResponseBuilder.cpp
@@ -4,12 +4,17 @@
  * Constructor & Destructor
  */
 
+AResponseBuilder::AResponseBuilder(void) : _isDone(false), _type(NONE) {}
+
 AResponseBuilder::AResponseBuilder(EBuilderType const& type,
                                    Request const& request)
-    : _request(request), _type(type) {}
+    : _isDone(false), _request(request), _type(type) {}
 
 AResponseBuilder::AResponseBuilder(AResponseBuilder const& builder)
-    : _request(builder._request), _type(builder._type) {}
+    : _response(builder._response),
+      _isDone(builder._isDone),
+      _request(builder._request),
+      _type(builder._type) {}
 
 AResponseBuilder::~AResponseBuilder(void) {}
 
@@ -19,24 +24,37 @@ AResponseBuilder::~AResponseBuilder(void) {}
 
 AResponseBuilder& AResponseBuilder::operator=(AResponseBuilder const& builder) {
   if (this != &builder) {
-    _type = builder._type;
     _response = builder._response;
+    _isDone = builder._isDone;
+    _request = builder._request;
+    _type = builder._type;
   }
   return *this;
 }
 
 /**
- * Protected method - setter
- */
-
-void AResponseBuilder::setType(EBuilderType const& type) { _type = type; }
-
-/**
  * Public method
  */
+
+void AResponseBuilder::build(void) {}
+void AResponseBuilder::close(void) {}
 
 AResponseBuilder::EBuilderType const& AResponseBuilder::getType(void) const {
   return _type;
 }
 
 Response const& AResponseBuilder::getResponse(void) const { return _response; }
+
+bool AResponseBuilder::isDone(void) const { return _isDone; }
+
+/**
+ * Protected method - setter
+ */
+
+Request const& AResponseBuilder::getRequest(void) const { return _request; }
+
+void AResponseBuilder::setRequest(Request const& request) {
+  _request = request;
+}
+
+void AResponseBuilder::setType(EBuilderType const& type) { _type = type; }

--- a/http/AResponseBuilder.hpp
+++ b/http/AResponseBuilder.hpp
@@ -20,7 +20,7 @@ class AResponseBuilder {
   AResponseBuilder(void);
   AResponseBuilder(EBuilderType const& type, Request const& request);
   AResponseBuilder(AResponseBuilder const& builder);
-  ~AResponseBuilder(void);
+  virtual ~AResponseBuilder(void);
 
   AResponseBuilder& operator=(AResponseBuilder const& builder);
 

--- a/http/AResponseBuilder.hpp
+++ b/http/AResponseBuilder.hpp
@@ -5,32 +5,39 @@
 #include "Response.hpp"
 
 class AResponseBuilder {
+ public:
+  enum EBuilderType { ERROR, NONE };
+
  protected:
-  enum EBuilderType { ERROR };
-  Request const& _request;
   Response _response;
+  bool _isDone;
 
  private:
+  Request _request;
   EBuilderType _type;
 
  public:
-  EBuilderType const& getType(void) const;
-  Response const& getResponse(void) const;
-
-  virtual void build(void) = 0;
-  virtual void close(void) = 0;
-
- protected:
+  AResponseBuilder(void);
   AResponseBuilder(EBuilderType const& type, Request const& request);
   AResponseBuilder(AResponseBuilder const& builder);
   ~AResponseBuilder(void);
 
   AResponseBuilder& operator=(AResponseBuilder const& builder);
 
+  EBuilderType const& getType(void) const;
+  Response const& getResponse(void) const;
+  bool isDone(void) const;
+
+  virtual void build(void);
+  virtual void close(void);
+
+ protected:
+  Request const& getRequest(void) const;
+
+  void setRequest(Request const& request);
   void setType(EBuilderType const& type);
 
  private:
-  AResponseBuilder(void);
 };
 
 #endif

--- a/http/AResponseBuilder.hpp
+++ b/http/AResponseBuilder.hpp
@@ -6,7 +6,7 @@
 
 class AResponseBuilder {
  public:
-  enum EBuilderType { ERROR, NONE };
+  enum EBuilderType { ERROR };
 
  protected:
   Response _response;
@@ -17,7 +17,6 @@ class AResponseBuilder {
   EBuilderType _type;
 
  public:
-  AResponseBuilder(void);
   AResponseBuilder(EBuilderType const& type, Request const& request);
   AResponseBuilder(AResponseBuilder const& builder);
   virtual ~AResponseBuilder(void);
@@ -28,8 +27,8 @@ class AResponseBuilder {
   Response const& getResponse(void) const;
   bool isDone(void) const;
 
-  virtual void build(void);
-  virtual void close(void);
+  virtual void build(void) = 0;
+  virtual void close(void) = 0;
 
  protected:
   Request const& getRequest(void) const;
@@ -38,6 +37,7 @@ class AResponseBuilder {
   void setType(EBuilderType const& type);
 
  private:
+  AResponseBuilder(void);
 };
 
 #endif

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -44,7 +44,6 @@ ErrorBuilder& ErrorBuilder::operator=(ErrorBuilder const& builder) {
 #include <iostream>
 
 void ErrorBuilder::build(void) {
-  std::cout << "error builder!" << std::endl;
   if (_recursiveFlag) {
     generateDefaultPage();
     return;

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -4,8 +4,6 @@
  * Constructor & Destructor
  */
 
-ErrorBuilder::ErrorBuilder(void) : AResponseBuilder(), _statusCode(500) {}
-
 ErrorBuilder::ErrorBuilder(Request const& request, int statusCode)
     : AResponseBuilder(ERROR, request), _statusCode(statusCode) {}
 
@@ -14,6 +12,7 @@ ErrorBuilder::ErrorBuilder(ErrorBuilder const& builder)
   _statusCode = builder._statusCode;
 }
 
+// TODO: 소멸할 때 관련된 fd를 clear하도록 구현
 ErrorBuilder::~ErrorBuilder(void) {}
 
 /**

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -4,6 +4,8 @@
  * Constructor & Destructor
  */
 
+ErrorBuilder::ErrorBuilder(void) : AResponseBuilder(), _statusCode(500) {}
+
 ErrorBuilder::ErrorBuilder(Request const& request, int statusCode)
     : AResponseBuilder(ERROR, request), _statusCode(statusCode) {}
 
@@ -20,8 +22,10 @@ ErrorBuilder::~ErrorBuilder(void) {}
 
 ErrorBuilder& ErrorBuilder::operator=(ErrorBuilder const& builder) {
   if (this != &builder) {
-    setType(builder.getType());
     _response = builder._response;
+    _isDone = builder._isDone;
+    setRequest(builder.getRequest());
+    setType(builder.getType());
     _statusCode = builder._statusCode;
   }
   return *this;
@@ -31,7 +35,10 @@ ErrorBuilder& ErrorBuilder::operator=(ErrorBuilder const& builder) {
  * Public method
  */
 
+#include <iostream>
+
 void ErrorBuilder::build(void) {
+  std::cout << "error builder!" << std::endl;
   generateDefaultPage();
 
   // Location const& location = _request.getLocation();
@@ -68,4 +75,6 @@ void ErrorBuilder::generateDefaultPage(void) {
   _response.appendBody(body);
 
   _response.makeResponseContent();
+
+  _isDone = true;
 }

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -4,8 +4,15 @@
  * Constructor & Destructor
  */
 
+ErrorBuilder::ErrorBuilder(void)
+    : AResponseBuilder(ERROR, Request()),
+      _statusCode(500),
+      _recursiveFlag(true) {}
+
 ErrorBuilder::ErrorBuilder(Request const& request, int statusCode)
-    : AResponseBuilder(ERROR, request), _statusCode(statusCode) {}
+    : AResponseBuilder(ERROR, request),
+      _statusCode(statusCode),
+      _recursiveFlag(false) {}
 
 ErrorBuilder::ErrorBuilder(ErrorBuilder const& builder)
     : AResponseBuilder(builder) {
@@ -38,14 +45,20 @@ ErrorBuilder& ErrorBuilder::operator=(ErrorBuilder const& builder) {
 
 void ErrorBuilder::build(void) {
   std::cout << "error builder!" << std::endl;
+  if (_recursiveFlag) {
+    generateDefaultPage();
+    return;
+  }
   generateDefaultPage();
 
-  // Location const& location = _request.getLocation();
-  // if (location.hasErrorPage(_statusCode)) {
-  //   readStatusCodeFile();
-  // } else {
-  //   generateDefaultPage();
+  // if (_request.getLocationFlag()) {
+  //   Location const& location = _request.getLocation();
+  //   if (location.hasErrorPage(_statusCode)) {
+  //     readStatusCodeFile();
+  //     return;
+  //   }
   // }
+  // generateDefaultPage();
 }
 
 void ErrorBuilder::close(void) {}

--- a/http/ErrorBuilder.hpp
+++ b/http/ErrorBuilder.hpp
@@ -9,6 +9,7 @@ class ErrorBuilder : public AResponseBuilder {
   int _statusCode;
 
  public:
+  ErrorBuilder(void);
   ErrorBuilder(Request const& request, int statusCode);
   ErrorBuilder(ErrorBuilder const& builder);
   ~ErrorBuilder(void);
@@ -19,7 +20,6 @@ class ErrorBuilder : public AResponseBuilder {
   virtual void close(void);
 
  private:
-  ErrorBuilder(void);
 
   void readStatusCodeFile(void);
   void generateDefaultPage(void);

--- a/http/ErrorBuilder.hpp
+++ b/http/ErrorBuilder.hpp
@@ -12,7 +12,7 @@ class ErrorBuilder : public AResponseBuilder {
   ErrorBuilder(void);
   ErrorBuilder(Request const& request, int statusCode);
   ErrorBuilder(ErrorBuilder const& builder);
-  ~ErrorBuilder(void);
+  virtual ~ErrorBuilder(void);
 
   ErrorBuilder& operator=(ErrorBuilder const& builder);
 
@@ -20,7 +20,6 @@ class ErrorBuilder : public AResponseBuilder {
   virtual void close(void);
 
  private:
-
   void readStatusCodeFile(void);
   void generateDefaultPage(void);
 };

--- a/http/ErrorBuilder.hpp
+++ b/http/ErrorBuilder.hpp
@@ -7,8 +7,10 @@
 class ErrorBuilder : public AResponseBuilder {
  private:
   int _statusCode;
+  bool _recursiveFlag;
 
  public:
+  ErrorBuilder(void);
   ErrorBuilder(Request const& request, int statusCode);
   ErrorBuilder(ErrorBuilder const& builder);
   virtual ~ErrorBuilder(void);
@@ -19,7 +21,6 @@ class ErrorBuilder : public AResponseBuilder {
   virtual void close(void);
 
  private:
-  ErrorBuilder(void);
   void readStatusCodeFile(void);
   void generateDefaultPage(void);
 };

--- a/http/ErrorBuilder.hpp
+++ b/http/ErrorBuilder.hpp
@@ -9,7 +9,6 @@ class ErrorBuilder : public AResponseBuilder {
   int _statusCode;
 
  public:
-  ErrorBuilder(void);
   ErrorBuilder(Request const& request, int statusCode);
   ErrorBuilder(ErrorBuilder const& builder);
   virtual ~ErrorBuilder(void);
@@ -20,6 +19,7 @@ class ErrorBuilder : public AResponseBuilder {
   virtual void close(void);
 
  private:
+  ErrorBuilder(void);
   void readStatusCodeFile(void);
   void generateDefaultPage(void);
 };

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -137,10 +137,13 @@ bool Request::isHeaderFieldNameExists(std::string const& fieldName) const {
 // 해당 헤더 field-value의 존재를 확인하는 함수
 // - 해당 헤더 field-name이 없다면 false 반환
 bool Request::isHeaderFieldValueExists(std::string const& fieldName,
-                                       std::string const& fieldValue) {
-  if (isHeaderFieldNameExists(fieldName) == false) return false;
+                                       std::string const& fieldValue) const {
+  std::map<std::string, std::vector<std::string> >::const_iterator found =
+      _header.find(fieldName);
 
-  std::vector<std::string> const& fieldValues = _header[fieldName];
+  if (found == _header.end()) return false;
+
+  std::vector<std::string> const& fieldValues = found->second;
   std::vector<std::string>::const_iterator it =
       std::find(fieldValues.begin(), fieldValues.end(), fieldValue);
   return (it != fieldValues.end());

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -68,6 +68,8 @@ std::map<std::string, std::vector<std::string> > const& Request::getHeader(
 
 Location const& Request::getLocation(void) const { return _location; }
 
+bool Request::getLocationFlag(void) const { return _locationFlag; }
+
 std::string const& Request::getBody(void) const { return _body; }
 
 std::vector<std::string> const& Request::getHeaderFieldValues(

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -37,6 +37,7 @@ class Request {
   std::map<std::string, std::vector<std::string> > const& getHeader(void) const;
   std::string const& getBody(void) const;
   Location const& getLocation(void) const;
+  bool getLocationFlag(void) const;
 
   std::vector<std::string> const& getHeaderFieldValues(
       std::string const& fieldName) const;

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -51,7 +51,7 @@ class Request {
 
   bool isHeaderFieldNameExists(std::string const& fieldName) const;
   bool isHeaderFieldValueExists(std::string const& fieldName,
-                                std::string const& fieldValue);
+                                std::string const& fieldValue) const;
 
   void clear(void);
 

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -125,8 +125,6 @@ bool Connection::isReadStorageRequired() {
 void Connection::selectResponseBuilder(void) {
   std::cout << "selected!" << std::endl;
   _responseBuilder = new ErrorBuilder(_requestParser.getRequest(), 200);
-
-  _responseBuilder->build();
   setStatus(ON_BUILD);
 }
 
@@ -167,6 +165,40 @@ void Connection::send(void) {
     setStatus(CLOSE);
   } else {
     setStatus(ON_WAIT);
+  }
+}
+
+void Connection::resetResponseBuilder(int code) {
+  Kqueue::removeAllEvents(_fd);
+
+  if (_responseBuilder != NULL) {
+    delete _responseBuilder;
+    _responseBuilder = NULL;
+  }
+
+  _responseBuilder = new ErrorBuilder(_requestParser.getRequest(), code);
+  setStatus(ON_BUILD);
+
+  build();
+  if (_status == Connection::ON_SEND) {
+    Kqueue::addWriteEvent(_fd);
+  }
+}
+
+void Connection::resetResponseBuilder(void) {
+  Kqueue::removeAllEvents(_fd);
+
+  if (_responseBuilder != NULL) {
+    delete _responseBuilder;
+    _responseBuilder = NULL;
+  }
+
+  _responseBuilder = new ErrorBuilder();
+  setStatus(ON_BUILD);
+
+  build();
+  if (_status == Connection::ON_SEND) {
+    Kqueue::addWriteEvent(_fd);
   }
 }
 

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -7,8 +7,6 @@
 
 #include "../config/Location.hpp"
 #include "../core/Kqueue.hpp"
-#include "../http/AResponseBuilder.hpp"
-#include "../http/ErrorBuilder.hpp"
 #include "../utils/Config.hpp"
 
 /**
@@ -20,6 +18,7 @@ Connection::Connection(int fd, ServerManager& manager)
       _lastCallTime(std::time(0)),
       _status(ON_WAIT),
       _requestParser(),
+      _responseBuilder(ErrorBuilder()),
       _manager(manager) {}
 
 Connection::Connection(Connection const& connection)
@@ -40,6 +39,7 @@ Connection& Connection::operator=(Connection const& connection) {
     _status = connection._status;
     _requestParser = connection._requestParser;
     _manager = connection._manager;
+    _responseBuilder = connection._responseBuilder;
   }
   return *this;
 }
@@ -52,7 +52,10 @@ Connection& Connection::operator=(Connection const& connection) {
 // - 읽기에 실패한 경우 예외 발생
 // - 클라이언트 연결 종료가 감지된 경우 status를 CLOSE로 바꿈
 void Connection::readSocket(void) {
-  setStatus(ON_RECV);
+  if (_status == ON_WAIT) {
+    _requestParser.clear();
+    setStatus(ON_RECV);
+  }
 
   u_int8_t buffer[BUFFER_SIZE];
   memset(buffer, 0, BUFFER_SIZE);
@@ -74,7 +77,10 @@ void Connection::readSocket(void) {
 // storage에 있는 요청 읽기
 // - 읽기에 실패한 경우 예외 발생
 void Connection::readStorage(void) {
-  setStatus(ON_RECV);
+  if (_status == ON_WAIT) {
+    _requestParser.clear();
+    setStatus(ON_RECV);
+  }
 
   u_int8_t tmp[1];
 
@@ -101,12 +107,11 @@ void Connection::parseRequest(u_int8_t const* buffer, ssize_t bytesRead) {
     if (_requestParser.getParsingStatus() == DONE) {
       setStatus(TO_SEND);
 
+      // debug
       Request const& request = _requestParser.getRequest();
       request.print();
 
-      // 응답 만들기
-      // WRITE 등록
-      _requestParser.clear();
+      // _requestParser.clear();
     }
 
   } catch (std::exception& e) {
@@ -126,41 +131,30 @@ bool Connection::isReadStorageRequired() {
  * Public method - response
  */
 
+// HTTP 요청 + Location 블록을 보고 분기
+// - 적절한 ResponseBuilder 선택
+void Connection::selectResponseBuilder(void) {
+  std::cout << "selected!" << std::endl;
+  _responseBuilder = ErrorBuilder(_requestParser.getRequest(), 200);
+
+  _responseBuilder.build();
+  setStatus(ON_BUILD);
+}
+
+// HTTP 응답 만들기
+void Connection::build() {
+  _responseBuilder.build();
+
+  if (_responseBuilder.isDone()) {
+    setStatus(ON_SEND);
+    _responseBuilder.close();
+  }
+}
+
 // 응답 보내기
 // - 임시 메서드
 void Connection::send(void) {
-  setStatus(ON_SEND);
-
-  char const* response =
-      "HTTP/1.1 200 OK\nContent-Length: 13\nContent-Type: "
-      "text/plain\nConnection: keep-alive\n\nHello, "
-      "world!\n\n";
-  ssize_t bytesSent = write(_fd, response, strlen(response));
-
-  if (bytesSent < 0) {
-    throw std::runtime_error("[4001] Connection: send - fail to write socket");
-  }
-
-  std::cout << "[ Server: response sent ]\n"
-            << "-------------\n"
-            << response << "\n-------------" << std::endl;
-  updateLastCallTime();
-
-  setStatus(ON_WAIT);
-}
-
-// 에러 응답 보내기
-// - 임시 메서드
-// - 이후에 ErrorBuilder를 통해 만들어질 예정
-void Connection::sendErrorPage(int code) {
-  setStatus(ON_SEND);
-
-  // HTTP 응답 생성
-
-  ErrorBuilder builder(_requestParser.getRequest(), code);
-  builder.build();
-
-  Response const& response = builder.getResponse();
+  Response const& response = _responseBuilder.getResponse();
   std::string const& responseContent = response.toString();
 
   ssize_t bytesSent =
@@ -177,7 +171,14 @@ void Connection::sendErrorPage(int code) {
 
   updateLastCallTime();
 
-  setStatus(ON_WAIT);
+  // ERROR BUILDER or Request -> Connection: close
+  Request const& request = _requestParser.getRequest();
+  if (_responseBuilder.getType() == AResponseBuilder::ERROR or
+      request.isHeaderFieldValueExists("connection", "Close")) {
+    setStatus(CLOSE);
+  } else {
+    setStatus(ON_WAIT);
+  }
 }
 
 /**

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -123,7 +123,6 @@ bool Connection::isReadStorageRequired() {
 // HTTP 요청 + Location 블록을 보고 분기
 // - 적절한 ResponseBuilder 선택
 void Connection::selectResponseBuilder(void) {
-  std::cout << "selected!" << std::endl;
   _responseBuilder = new ErrorBuilder(_requestParser.getRequest(), 200);
   setStatus(ON_BUILD);
 }

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -4,6 +4,8 @@
 #include <ctime>
 #include <string>
 
+#include "../http/AResponseBuilder.hpp"
+#include "../http/ErrorBuilder.hpp"
 #include "../http/Request.hpp"
 #include "../http/RequestParser.hpp"
 #include "ServerManager.hpp"
@@ -13,7 +15,7 @@ class ServerManager;
 // 클라이언트 연결을 관리하는 클래스
 class Connection {
  public:
-  enum EStatus { ON_WAIT, ON_RECV, TO_SEND, ON_SEND, CLOSE };
+  enum EStatus { ON_WAIT, ON_RECV, TO_SEND, ON_BUILD, ON_SEND, CLOSE };
 
  private:
   int _fd;
@@ -21,6 +23,7 @@ class Connection {
   enum EStatus _status;
 
   RequestParser _requestParser;
+  AResponseBuilder _responseBuilder;
 
  public:
   Connection(int fd, ServerManager& manager);
@@ -33,8 +36,10 @@ class Connection {
   void readStorage(void);
   bool isReadStorageRequired(void);
 
+  void selectResponseBuilder(void);
+  void build(void);
+
   void send(void);
-  void sendErrorPage(int code);
 
   void close(void);
 

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -23,7 +23,7 @@ class Connection {
   enum EStatus _status;
 
   RequestParser _requestParser;
-  AResponseBuilder _responseBuilder;
+  AResponseBuilder* _responseBuilder;
 
  public:
   Connection(int fd, ServerManager& manager);
@@ -41,6 +41,7 @@ class Connection {
 
   void send(void);
 
+  void clear(void);
   void close(void);
 
   int getFd(void) const;

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -38,8 +38,10 @@ class Connection {
 
   void selectResponseBuilder(void);
   void build(void);
-
   void send(void);
+
+  void resetResponseBuilder(int code);
+  void resetResponseBuilder(void);
 
   void clear(void);
   void close(void);

--- a/server/EventLoop.cpp
+++ b/server/EventLoop.cpp
@@ -52,8 +52,6 @@ void EventLoop::run(void) {
         continue;
       }
 
-      std::cout << "event!" << std::endl;
-
       ManagerMap::iterator it = _managers.begin();
       while (it != _managers.end()) {
         ServerManager& manager = it->second;

--- a/server/EventLoop.cpp
+++ b/server/EventLoop.cpp
@@ -52,6 +52,8 @@ void EventLoop::run(void) {
         continue;
       }
 
+      std::cout << "event!" << std::endl;
+
       ManagerMap::iterator it = _managers.begin();
       while (it != _managers.end()) {
         ServerManager& manager = it->second;

--- a/server/ServerManager.cpp
+++ b/server/ServerManager.cpp
@@ -78,7 +78,7 @@ void ServerManager::run(void) {
 void ServerManager::clear(void) {
   for (ConnectionMap::iterator it = _connections.begin();
        it != _connections.end(); ++it) {
-    (*it).second.close();
+    removeConnection(it->first);
   }
   _connections.clear();
   _managedFds.clear();
@@ -203,6 +203,7 @@ void ServerManager::handleWriteEvent(int eventFd) {
     }
 
     if (connection.getConnectionStatus() == Connection::ON_WAIT) {
+      connection.clear();
       Kqueue::removeWriteEvent(eventFd);
       Kqueue::addReadEvent(eventFd);
     }
@@ -357,6 +358,7 @@ void ServerManager::removeConnection(int fd) {
   Connection& connection = it->second;
   removeAllManagedFd(fd);
   Kqueue::removeAllEvents(fd);
+  connection.clear();
   connection.close();
   _connections.erase(fd);
 }

--- a/server/ServerManager.cpp
+++ b/server/ServerManager.cpp
@@ -108,125 +108,26 @@ void ServerManager::handleEvent(Event event) {
     return;
   }
 
-  // 클라이언트 fd인 경우 이벤트 처리
-  switch (event.getType()) {
-    case Event::READ:
-      handleReadEvent(eventFd);
-      break;
-
-    case Event::WRITE:
-      handleWriteEvent(eventFd);
-      break;
-
-    default:
-      throw std::runtime_error(
-          "[4103] ServerManager: handleEvent - unknown event type");
-  }
-}
-
-// 커넥션 추가 이벤트 처리
-// - 예외 발생 시 자원 정리 후 예외 전달
-void ServerManager::handleServerEvent(void) {
-  int clientFd = -1;
+  Connection& connection = findConnection(eventFd);
 
   try {
-    clientFd = Socket::accept(_serverFd);
+    // 클라이언트 fd인 경우 이벤트 처리
+    switch (event.getType()) {
+      case Event::READ:
+        handleReadEvent(eventFd, connection);
+        break;
 
-    addManagedFd(clientFd, clientFd);
-    addConnection(clientFd);
-    Kqueue::addReadEvent(clientFd);
-  } catch (std::exception const& e) {
-    if (hasConnectionFd(clientFd)) {
-      removeConnection(clientFd);
-    } else if (clientFd != -1) {
-      close(clientFd);
+      case Event::WRITE:
+        handleWriteEvent(eventFd, connection);
+        break;
+
+      default:
+        throw std::runtime_error(
+            "[4103] ServerManager: handleEvent - unknown event type");
     }
-    throw;
-  }
-}
-
-// 읽기 이벤트 처리
-// - 이벤트 처리 과정 중 예외 발생 가능
-void ServerManager::handleReadEvent(int eventFd) {
-  int connectionFd = _managedFds[eventFd];
-  ConnectionMap::iterator it = _connections.find(connectionFd);
-  Connection& connection = it->second;
-
-  try {
-    if (connection.getConnectionStatus() == Connection::ON_WAIT or
-        connection.getConnectionStatus() == Connection::ON_RECV) {
-      connection.readSocket();
-    }
-
-    if (connection.getConnectionStatus() == Connection::TO_SEND) {
-      Kqueue::removeReadEvent(eventFd);
-      connection.selectResponseBuilder();
-    }
-
-    if (connection.getConnectionStatus() == Connection::ON_BUILD) {
-      std::cout << "build!" << std::endl;
-      connection.build();
-
-      if (connection.getConnectionStatus() == Connection::ON_SEND) {
-        Kqueue::addWriteEvent(eventFd);
-      }
-    }
-
-    if (connection.getConnectionStatus() == Connection::CLOSE) {
-      removeConnection(eventFd);
-    }
-
-  } catch (StatusException const& e) {
-    // int code = e.getStatusCode();
-    connection.send();  // TODO
-    removeConnection(connection.getFd());
   } catch (std::exception const& e) {
     std::cout << e.what() << std::endl;
-    connection.send();  // TODO
-    removeConnection(connection.getFd());
-  }
-}
-
-// 쓰기 이벤트 처리
-// - 이벤트 처리 과정 중 예외 발생 가능
-void ServerManager::handleWriteEvent(int eventFd) {
-  int connectionFd = _managedFds[eventFd];
-  ConnectionMap::iterator it = _connections.find(connectionFd);
-  Connection& connection = it->second;
-
-  try {
-    connection.send();
-
-    if (connection.getConnectionStatus() == Connection::CLOSE) {
-      removeConnection(eventFd);
-      return;
-    }
-
-    if (connection.getConnectionStatus() == Connection::ON_WAIT) {
-      connection.clear();
-      Kqueue::removeWriteEvent(eventFd);
-      Kqueue::addReadEvent(eventFd);
-    }
-
-    if (connection.getConnectionStatus() == Connection::ON_WAIT and
-        connection.isReadStorageRequired()) {
-      Kqueue::removeReadEvent(eventFd);
-      connection.readStorage();
-      if (connection.getConnectionStatus() == Connection::TO_SEND) {
-        Kqueue::addWriteEvent(eventFd);
-      } else {
-        Kqueue::addReadEvent(eventFd);
-      }
-      return;
-    }
-
-  } catch (StatusException const& e) {
-    // int code = e.getStatusCode();
-    connection.send();  // TODO
-    removeConnection(connection.getFd());
-  } catch (std::exception const& e) {
-    connection.send();  // TODO
-    removeConnection(connection.getFd());
+    connection.resetResponseBuilder();
   }
 }
 
@@ -366,4 +267,122 @@ void ServerManager::removeConnection(int fd) {
 // 커넥션 중 해당하는 fd가 있는지 확인
 bool ServerManager::hasConnectionFd(int fd) const {
   return (_connections.find(fd) != _connections.end());
+}
+
+// 커넥션 추가 이벤트 처리
+// - 예외 발생 시 자원 정리 후 예외 전달
+void ServerManager::handleServerEvent(void) {
+  int clientFd = -1;
+
+  try {
+    clientFd = Socket::accept(_serverFd);
+
+    addManagedFd(clientFd, clientFd);
+    addConnection(clientFd);
+    Kqueue::addReadEvent(clientFd);
+  } catch (std::exception const& e) {
+    if (hasConnectionFd(clientFd)) {
+      removeConnection(clientFd);
+    } else if (clientFd != -1) {
+      close(clientFd);
+    }
+    throw;
+  }
+}
+
+// 읽기 이벤트 처리
+// - 이벤트 처리 과정 중 예외 발생 가능
+void ServerManager::handleReadEvent(int eventFd, Connection& connection) {
+  try {
+    if (connection.getConnectionStatus() == Connection::ON_WAIT or
+        connection.getConnectionStatus() == Connection::ON_RECV) {
+      connection.readSocket();
+    }
+
+    if (connection.getConnectionStatus() == Connection::TO_SEND) {
+      std::cout << "eventFd" << eventFd << std::endl;
+      Kqueue::removeReadEvent(eventFd);
+      std::cout << "after eventFd: " << Kqueue::_events[eventFd] << std::endl;
+
+      connection.selectResponseBuilder();
+    }
+
+    throw StatusException(HTTP_NOT_ALLOWED, "hi");
+
+    if (connection.getConnectionStatus() == Connection::ON_BUILD) {
+      std::cout << "build!" << std::endl;
+      connection.build();
+
+      if (connection.getConnectionStatus() == Connection::ON_SEND) {
+        Kqueue::addWriteEvent(eventFd);
+        std::cout << "after write eventFd: " << Kqueue::_events[eventFd]
+                  << std::endl;
+      }
+    }
+
+    if (connection.getConnectionStatus() == Connection::CLOSE) {
+      std::cout << "after2 eventFd: " << Kqueue::_events[eventFd] << std::endl;
+      removeConnection(eventFd);
+    }
+
+  } catch (StatusException const& e) {
+    std::cout << e.what() << std::endl;
+    throw StatusException(HTTP_BAD_GATEWAY, "hi");
+
+    int code = e.getStatusCode();
+    connection.resetResponseBuilder(code);
+  } catch (std::exception const& e) {
+    std::cout << e.what() << std::endl;
+
+    connection.resetResponseBuilder(500);
+  }
+}
+
+// 쓰기 이벤트 처리
+// - 이벤트 처리 과정 중 예외 발생 가능
+void ServerManager::handleWriteEvent(int eventFd, Connection& connection) {
+  try {
+    connection.send();
+
+    if (connection.getConnectionStatus() == Connection::CLOSE) {
+      removeConnection(eventFd);
+      return;
+    }
+
+    std::cout << connection.getConnectionStatus() << std::endl;
+    if (connection.getConnectionStatus() == Connection::ON_WAIT) {
+      connection.clear();
+      Kqueue::removeWriteEvent(eventFd);
+      Kqueue::addReadEvent(eventFd);
+    }
+
+    if (connection.getConnectionStatus() == Connection::ON_WAIT and
+        connection.isReadStorageRequired()) {
+      Kqueue::removeReadEvent(eventFd);
+      connection.readStorage();
+      if (connection.getConnectionStatus() == Connection::TO_SEND) {
+        Kqueue::addWriteEvent(eventFd);
+      } else {
+        Kqueue::addReadEvent(eventFd);
+      }
+      return;
+    }
+    std::cout << connection.getConnectionStatus() << std::endl;
+
+  } catch (StatusException const& e) {
+    std::cout << e.what() << std::endl;
+
+    int code = e.getStatusCode();
+    connection.resetResponseBuilder(code);
+  } catch (std::exception const& e) {
+    std::cout << e.what() << std::endl;
+
+    connection.resetResponseBuilder(500);
+  }
+}
+
+Connection& ServerManager::findConnection(int eventFd) {
+  int connectionFd = _managedFds[eventFd];
+  ConnectionMap::iterator it = _connections.find(connectionFd);
+  return it->second;
 }

--- a/server/ServerManager.hpp
+++ b/server/ServerManager.hpp
@@ -57,8 +57,9 @@ class ServerManager {
   void removeAllManagedFd(int managedFd);
 
   void handleServerEvent(void);
-  void handleReadEvent(int eventFd);
-  void handleWriteEvent(int eventFd);
+  void handleReadEvent(int eventFd, Connection& connection);
+  void handleWriteEvent(int eventFd, Connection& connection);
+  Connection& findConnection(int eventFd);
 
   ServerManager(void);
 };


### PR DESCRIPTION
## 구현 사항

### 전체적인 응답 생성 및 전송 흐름 설계 구현
- `Connection::EStauts`에 `ON_BUILD` 상태 추가
- `TO_SEND` 상태인 경우 Read 이벤트 제거 및 Response Builder 선택 후 `ON_BUILD`로 상태 변경
- `ON_BUILD` 상태인 경우 응답 생성
  - 응답 생성이 완료된 경우 `ON_SEND`로 상태 변경
- `ON_SEND` 상태인 경우 응답 전송을 위해 Write 이벤트 등록
- `CLOSE` 상태인 경우 클라이언트와 연결 종료
- `ON_WAIT` 상태인 경우 다시 요청을 읽을 수 있도록 Read 이벤트 등록
  - 만약 이 상태에서 Storage를 읽어야 하는 경우는 따로 처리
```c++
// Connection.hpp
enum EStatus { ON_WAIT, ON_RECV, TO_SEND, ON_BUILD, ON_SEND, CLOSE };

// ServerManager.cpp
// - read
if (connection.getConnectionStatus() == Connection::TO_SEND) {
  Kqueue::removeReadEvent(eventFd);
  connection.selectResponseBuilder();
}

if (connection.getConnectionStatus() == Connection::ON_BUILD) {
  connection.build();
  if (connection.getConnectionStatus() == Connection::ON_SEND) {
    Kqueue::addWriteEvent(eventFd);
  }
}

// - write
if (connection.getConnectionStatus() == Connection::CLOSE) {
  removeConnection(eventFd);
  return;
}

if (connection.getConnectionStatus() == Connection::ON_WAIT) {
  Kqueue::removeWriteEvent(eventFd);
  Kqueue::addReadEvent(eventFd);
}
``` 

### Connection에서 AResponseBuilder 멤버 변수를 포인터로 선언하도록 변경
- 생성자에서 NULL로 초기화
- connection clear 함수 구현
  - requestParser clear 함수 호출
  - 동적할당한 builder를 delete 후 NULL로 초기화
- 응답 전송이 끝났거나 예외 발생 시 clear 함수 호출하도록 변경

### 예외 발생 시 ErrorBuilder 재할당
- `Connection:` 예외 발생 시 ErrorBuilder로 전환할 수 있는 함수 구현
- `ServerManager`: 반복 예외 발생 시 기본 에러 페이지 전송 로직 구현
- 에러가 반복 호출 됐을 시 판단할 수 있는 _recursiveFlag 추가
- 예외가 반복된 경우 ErrorBuilder를 생성할 때 기본 생성자 호출

### kqueue addWriteEvent 오타 수정
- `addWriteEvent` 함수에서 `READ_EVENT`를 등록한 것처럼 이벤트 상태를 업데이트 해서 오류 발생하여 수정

### Issue
- #39