### PR TITLE
[Feat] 버퍼 사이즈만큼 HTTP 응답 전송

### DIFF
--- a/http/AResponseBuilder.cpp
+++ b/http/AResponseBuilder.cpp
@@ -38,7 +38,7 @@ AResponseBuilder::EBuilderType const& AResponseBuilder::getType(void) const {
   return _type;
 }
 
-Response const& AResponseBuilder::getResponse(void) const { return _response; }
+Response& AResponseBuilder::getResponse(void) { return _response; }
 
 bool AResponseBuilder::isDone(void) const { return _isDone; }
 

--- a/http/AResponseBuilder.hpp
+++ b/http/AResponseBuilder.hpp
@@ -24,7 +24,7 @@ class AResponseBuilder {
   AResponseBuilder& operator=(AResponseBuilder const& builder);
 
   EBuilderType const& getType(void) const;
-  Response const& getResponse(void) const;
+  Response& getResponse(void);
   bool isDone(void) const;
 
   virtual void build(void) = 0;

--- a/http/Response.cpp
+++ b/http/Response.cpp
@@ -4,7 +4,7 @@
 
 Response::Response(void)
     : _responseContent(""),
-      _startIndex(-1),
+      _startIndex(0),
       _httpVersion(""),
       _statusCode(-1),
       _body("") {}
@@ -60,6 +60,8 @@ std::map<std::string, std::string> const& Response::getHeader(void) const {
 
 std::string const& Response::getBody(void) const { return _body; }
 
+size_t Response::getStartIndex(void) const { return _startIndex; }
+
 std::string const& Response::toString(void) const { return _responseContent; }
 
 // Public Method - setter
@@ -80,7 +82,6 @@ void Response::makeResponseContent(void) {
   ss << _body;
 
   _responseContent = ss.str();
-  _startIndex = 0;
 }
 
 void Response::setHttpVersion(std::string const& httpVersion) {
@@ -89,6 +90,10 @@ void Response::setHttpVersion(std::string const& httpVersion) {
 
 void Response::setStatusCode(int const& statusCode) {
   _statusCode = statusCode;
+}
+
+void Response::setStartIndex(size_t const& startIndex) {
+  _startIndex = startIndex;
 }
 
 // Public Method
@@ -110,7 +115,7 @@ void Response::appendBody(std::string const& body) { _body.append(body); }
 // 멤버 변수를 비어있는 상태로 초기화
 void Response::clear(void) {
   _responseContent.clear();
-  _startIndex = -1;
+  _startIndex = 0;
   _httpVersion.clear();
   _statusCode = -1;
   _header.clear();

--- a/http/Response.hpp
+++ b/http/Response.hpp
@@ -14,7 +14,7 @@
 class Response {
  private:
   std::string _responseContent;
-  ssize_t _startIndex;
+  size_t _startIndex;
 
   std::string _httpVersion;
   int _statusCode;
@@ -34,12 +34,15 @@ class Response {
   int const& getStatusCode(void) const;
   std::map<std::string, std::string> const& getHeader(void) const;
   std::string const& getBody(void) const;
+  size_t getStartIndex(void) const;
+
   std::string const& toString(void) const;
 
   void makeResponseContent(void);
 
   void setHttpVersion(std::string const& httpVersion);
   void setStatusCode(int const& statusCode);
+  void setStartIndex(size_t const& startIndex);
 
   void addHeader(std::string const& fieldName, std::string const& fieldValue);
   void appendBody(std::string const& body);

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -128,7 +128,7 @@ void Connection::selectResponseBuilder(void) {
 }
 
 // HTTP 응답 만들기
-void Connection::build() {
+void Connection::buildResponse() {
   _responseBuilder->build();
 
   if (_responseBuilder->isDone()) {
@@ -191,7 +191,7 @@ void Connection::resetResponseBuilder(int code) {
   _responseBuilder = new ErrorBuilder(_requestParser.getRequest(), code);
   setStatus(ON_BUILD);
 
-  build();
+  buildResponse();
   if (_status == Connection::ON_SEND) {
     Kqueue::addWriteEvent(_fd);
   }
@@ -208,7 +208,7 @@ void Connection::resetResponseBuilder(void) {
   _responseBuilder = new ErrorBuilder();
   setStatus(ON_BUILD);
 
-  build();
+  buildResponse();
   if (_status == Connection::ON_SEND) {
     Kqueue::addWriteEvent(_fd);
   }

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -37,7 +37,7 @@ class Connection {
   bool isReadStorageRequired(void);
 
   void selectResponseBuilder(void);
-  void build(void);
+  void buildResponse(void);
   void sendResponse(void);
 
   void resetResponseBuilder(int code);

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -38,7 +38,7 @@ class Connection {
 
   void selectResponseBuilder(void);
   void build(void);
-  void send(void);
+  void sendResponse(void);
 
   void resetResponseBuilder(int code);
   void resetResponseBuilder(void);

--- a/server/ServerManager.cpp
+++ b/server/ServerManager.cpp
@@ -334,7 +334,9 @@ void ServerManager::handleReadEvent(int eventFd, Connection& connection) {
 // - 이벤트 처리 과정 중 예외 발생 가능
 void ServerManager::handleWriteEvent(int eventFd, Connection& connection) {
   try {
-    connection.send();
+    if (connection.getConnectionStatus() == Connection::ON_SEND) {
+      connection.send();
+    }
 
     if (connection.getConnectionStatus() == Connection::CLOSE) {
       removeConnection(eventFd);

--- a/server/ServerManager.cpp
+++ b/server/ServerManager.cpp
@@ -307,7 +307,7 @@ void ServerManager::handleReadEvent(int eventFd, Connection& connection) {
     }
 
     if (connection.getConnectionStatus() == Connection::ON_BUILD) {
-      connection.build();
+      connection.buildResponse();
 
       if (connection.getConnectionStatus() == Connection::ON_SEND) {
         Kqueue::addWriteEvent(eventFd);
@@ -335,7 +335,7 @@ void ServerManager::handleReadEvent(int eventFd, Connection& connection) {
 void ServerManager::handleWriteEvent(int eventFd, Connection& connection) {
   try {
     if (connection.getConnectionStatus() == Connection::ON_SEND) {
-      connection.send();
+      connection.sendResponse();
     }
 
     if (connection.getConnectionStatus() == Connection::CLOSE) {


### PR DESCRIPTION
## 구현사항

### Response 클래스 멤버변수 _startIndex 타입 변경
- _startIndex는 응답을 전송할 때 ResponseContent의 startIndex 이전까지 전송했다는 것을 확인하기 위해 있는 멤버변수
- ssize_t에서 size_t로 자료형 변경
- 이전에 할당되지 않았을 경우 -1로 초기화 하기 위해 ssize_t를 사용하였으나 소켓에 전송할 때 size_t와 연산이 많아 변경
- 생성자 호출 및 clear 할 때 0으로 초기화
- getter, setter 구현

### AResponseBuilder::getResponse 함수 반환 자료형 변경
- 이전에 const&로 반환하였으나, 소켓에 전송할 때 startIndex를 set으로 변경해야 해서 &로 반환
```c++
// 변경 전
Response const& AResponseBuilder::getResponse(void) const { return _response; }

// 변경 후
Response& AResponseBuilder::getResponse(void) { return _response; }
``` 

### 버퍼 사이즈만큼 HTTP 응답 전송
- 현재 남은 응답 문자열 크기를 `contentLength`에 저장
- `min(contentLength, BUFFER_SIZE)`만큼 응답 전송 후 `startIndex` 업데이트
  - startIndex 업데이트는 모두 BUFFER_SIZE만큼 진행
- 응답을 모두 전송한 경우 상태 변경 (`CLOSE` 또는 `ON_WAIT`)

### Response 관련 함수명 변경
- send와 build 함수 뒤에 Response 접미사 추가