### PR TITLE
[Feat] AutoindexBuilder 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SRCS		= config/Server.cpp \
 			  config/Location.cpp \
 			  utils/StatusException.cpp \
 			  utils/Config.cpp \
-				utils/Util.cpp \
+			  utils/Util.cpp \
 			  core/Kqueue.cpp \
 			  core/Event.cpp \
 			  core/Socket.cpp \
@@ -18,6 +18,7 @@ SRCS		= config/Server.cpp \
 			  http/Response.cpp \
 			  http/AResponseBuilder.cpp \
 			  http/ErrorBuilder.cpp \
+			  http/AutoindexBuilder.cpp \
 			  main.cpp
 				
 

--- a/http/AResponseBuilder.hpp
+++ b/http/AResponseBuilder.hpp
@@ -8,7 +8,7 @@
 
 class AResponseBuilder {
  public:
-  enum EBuilderType { ERROR };
+  enum EBuilderType { ERROR, AUTOINDEX };
 
  protected:
   Response _response;

--- a/http/AutoindexBuilder.cpp
+++ b/http/AutoindexBuilder.cpp
@@ -70,12 +70,13 @@ int AutoindexBuilder::build(void) {
 
   if (method == HTTP_POST || location.isAutoIndex() == false) {
     throw StatusException(
-        HTTP_FORBIDDEN, "[] AutoindexBuilder: build - autoindex is forbidden");
+        HTTP_FORBIDDEN,
+        "[5203] AutoindexBuilder: build - autoindex is forbidden");
   }
 
   DIR* directory;
   if ((directory = opendir(fullPath.c_str())) == NULL)
-    throw std::runtime_error("[] AutoindexBuilder: build - opendir failed");
+    throw std::runtime_error("[5204] AutoindexBuilder: build - opendir failed");
 
   generateAutoindexPage(fullPath, path, directory);
   return -1;
@@ -112,7 +113,7 @@ void AutoindexBuilder::generateAutoindexPage(std::string const& fullPath,
 
     if (stat(filePath.c_str(), &fileStat) == -1) {
       throw std::runtime_error(
-          "[5203] AutoindexBuilder: generateAutoindexPage - stat failed: " +
+          "[5205] AutoindexBuilder: generateAutoindexPage - stat failed: " +
           filePath);
     }
 

--- a/http/AutoindexBuilder.cpp
+++ b/http/AutoindexBuilder.cpp
@@ -1,0 +1,151 @@
+#include "AutoindexBuilder.hpp"
+
+/**
+ * Constructor & Destructor
+ */
+
+AutoindexBuilder::AutoindexBuilder(Request const& request)
+    : AResponseBuilder(AUTOINDEX, request) {}
+
+AutoindexBuilder::AutoindexBuilder(AutoindexBuilder const& builder)
+    : AResponseBuilder(builder) {}
+
+AutoindexBuilder::~AutoindexBuilder(void) {}
+
+/**
+ * Operator Overloading
+ */
+
+AutoindexBuilder& AutoindexBuilder::operator=(AutoindexBuilder const& builder) {
+  if (this != &builder) {
+    _response = builder._response;
+    _isDone = builder._isDone;
+    setRequest(builder.getRequest());
+    setType(builder.getType());
+  }
+  return *this;
+}
+
+/**
+ * Public method
+ */
+
+// autoindex page 제작이 가능한지 확인 후 가능하다면 제작
+// - 가능한 경우가 아니라면 예외 발생
+int AutoindexBuilder::build(void) {
+  Request const& request = getRequest();
+  EHttpMethod const& method = request.getMethod();
+
+  if (method != HTTP_GET and method != HTTP_POST) {
+    throw StatusException(
+        HTTP_NOT_ALLOWED,
+        "[5200] AutoindexBuilder: build - http method not allowed");
+  }
+
+  Location const& location = request.getLocation();
+  std::string const& root = location.getRootPath();
+  std::string const& path = request.getPath();
+  std::string const& locationUri = location.getUri();
+
+  std::string fullPath;
+  size_t pos = path.find(locationUri);
+  if (pos != std::string::npos and pos == 0) {
+    fullPath = root + path.substr(locationUri.length());
+  } else {
+    fullPath = root + path;
+  }
+
+  if (access(fullPath.c_str(), F_OK) == -1) {
+    throw StatusException(
+        HTTP_NOT_FOUND,
+        "[5201] AutoindexBuilder: build - file not exist: " + fullPath);
+  }
+
+  if (access(fullPath.c_str(), R_OK) == -1) {
+    throw StatusException(
+        HTTP_INTERNAL_SERVER_ERROR,
+        "[5202] AutoindexBuilder: build - file permissions denied: " +
+            fullPath);
+  }
+
+  if (method == HTTP_POST || location.isAutoIndex() == false) {
+    throw StatusException(
+        HTTP_FORBIDDEN, "[] AutoindexBuilder: build - autoindex is forbidden");
+  }
+
+  DIR* directory;
+  if ((directory = opendir(fullPath.c_str())) == NULL)
+    throw std::runtime_error("[] AutoindexBuilder: build - opendir failed");
+
+  generateAutoindexPage(fullPath, path, directory);
+  return -1;
+}
+
+void AutoindexBuilder::close(void) {}
+
+/**
+ * Private method
+ */
+
+// autoindex page 제작
+void AutoindexBuilder::generateAutoindexPage(std::string const& fullPath,
+                                             std::string const& dirPath,
+                                             DIR* directory) {
+  struct dirent* entry;
+
+  std::stringstream ss;
+
+  ss << "<html> <head> <title>Index of " << dirPath
+     << "</title> <style> table { border - collapse : collapse; }"
+        "th, td { border: 1px solid black; padding: 10px; } </style> </head>";
+  ss << "<body> <h1>Index of " << dirPath << "</h1>\n";
+  ss << "<table> <tr> <th>filename</th> <th>last modified time</th> "
+        "<th>size</th> </tr> ";
+
+  struct stat fileStat;
+  while ((entry = readdir(directory)) != NULL) {
+    std::string fileName(entry->d_name);
+    std::string const& filePath = fullPath + fileName;
+    bool isDir = (entry->d_type == DT_DIR);
+
+    if (fileName == ".") continue;
+
+    if (stat(filePath.c_str(), &fileStat) == -1) {
+      throw std::runtime_error(
+          "[5203] AutoindexBuilder: generateAutoindexPage - stat failed: " +
+          filePath);
+    }
+
+    if (isDir) fileName += "/";
+
+    ss << "<tr> ";
+    ss << "<td> <a href=\"" << fileName << "\">" << fileName << "</a> </td>";
+    ss << "<td> " << std::ctime(&fileStat.st_mtime) << "</td>";
+    if (!isDir)
+      ss << "<td> " << fileStat.st_size << "</td>";
+    else
+      ss << "<td> - </td>";
+    ss << "</tr>";
+  }
+
+  ss << "</table> </body> <html>";
+
+  buildResponseContent(ss.str());
+}
+
+// Connection은 request Header 정보 보고 변경되어야 함
+void AutoindexBuilder::buildResponseContent(std::string const& body) {
+  // HTTP 응답 생성
+  _response.setHttpVersion("HTTP/1.1");
+  _response.setStatusCode(200);
+
+  _response.addHeader("Content-Type", "text/html");
+  _response.addHeader("Content-Length", Util::itos(body.size()));
+  _response.addHeader("Connection", "keep-alive");
+
+  _response.appendBody(body);
+
+  _response.makeResponseContent();
+
+  _isDone = true;
+}

--- a/http/AutoindexBuilder.hpp
+++ b/http/AutoindexBuilder.hpp
@@ -1,0 +1,34 @@
+#ifndef __AUTOINDEX_BUILDER_HPP__
+#define __AUTOINDEX_BUILDER_HPP__
+
+#include <dirent.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <ctime>
+#include <sstream>
+
+#include "../utils/StatusException.hpp"
+#include "../utils/Util.hpp"
+#include "AResponseBuilder.hpp"
+
+class AutoindexBuilder : public AResponseBuilder {
+ public:
+  AutoindexBuilder(Request const& request);
+  AutoindexBuilder(AutoindexBuilder const& builder);
+  virtual ~AutoindexBuilder(void);
+
+  AutoindexBuilder& operator=(AutoindexBuilder const& builder);
+
+  virtual int build(void);
+  virtual void close(void);
+
+ private:
+  AutoindexBuilder(void);
+
+  void generateAutoindexPage(std::string const& fullPath,
+                             std::string const& dirPath, DIR* directory);
+  virtual void buildResponseContent(std::string const& body);
+};
+
+#endif

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -127,6 +127,7 @@ bool Connection::isReadStorageRequired() {
 // HTTP 요청 + Location 블록을 보고 분기
 // - 적절한 ResponseBuilder 선택
 void Connection::selectResponseBuilder(void) {
+  // _responseBuilder = new AutoindexBuilder(_requestParser.getRequest());
   _responseBuilder = new ErrorBuilder(_requestParser.getRequest(), 200);
   setStatus(ON_BUILD);
 }

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "../http/AResponseBuilder.hpp"
+#include "../http/AutoindexBuilder.hpp"
 #include "../http/ErrorBuilder.hpp"
 #include "../http/Request.hpp"
 #include "../http/RequestParser.hpp"


### PR DESCRIPTION
## 구현 사항

### Autoindex Builder 구현
- `AResponseBuilder::EBuilderType`에 `AUTOINDEX` 타입 추가
- `build` 함수
  - fullPath 생성 (location이랑 겹치는 부분을 root로 변경 후 path와 join)
  - autoindex page가 제작이 가능한 지 확인
  - 가능하다면 `generateAutoindexPage` 함수 호출
- `generateAutoindexPage` 함수
  - `readdir` 함수를 통해 폴더 내부 파일을 하나씩 접근
  - `stat` 함수를 통해 파일 정보(이름, 최종 수정일자, 파일 크기)를 `stringstream`에 저장
  - 다 생성했다면 `buildResponseContent` 함수 호출

**[ autoindex page 제작 가능 여부 확인 로직 ]**
1. GET, HEAD, POST 요청이 아닌 경우 405 Not Allowed
2. 디렉토리가 존재하지 않으면 404 Not Found
3. 디렉토리가 존재하지만 권한이 없는 경우 500 Internal Server Error
4. 디렉토리가 존재하는 경우(권한 O)
  - 4-1. POST: 403 Forbidden
  - 4-2. autoindex on: GET, HEAD: 200 OK (디렉토리 인덱싱 html 동적 생성)
  - 4-3. autoindex off: GET, HEAD: 403 Forbidden

### 실행 결과
<img width="655" alt="Screen Shot 2024-01-22 at 10 06 40 PM" src="https://github.com/wonyangs/webserv/assets/44529556/384d6a26-b60f-4db0-8228-b8d4e8da7837">

## To-do!
- 현재 구현된 상태는 root 디렉토리에 / 가 붙어있다고 가정되어있기 때문에 config 블럭 파싱 구현 시 /가 없다면 추가해주어야 함
- fullPath를 만드는 부분이 build 함수 내부에서 구현되었는데, 추후 반복적으로 쓰일 것 같아 파싱 끝나고 한번 생성하는 부분으로 함수화
- 파일에 대한 존재 여부, 권한 여부 또한 반복적으로 사용될 것 같아 Util에 함수화 필요