### PR TITLE
[Feat] request 객체에서 full path 생성 후 저장

### DIFF
--- a/http/AutoindexBuilder.cpp
+++ b/http/AutoindexBuilder.cpp
@@ -43,17 +43,8 @@ int AutoindexBuilder::build(void) {
   }
 
   Location const& location = request.getLocation();
-  std::string const& root = location.getRootPath();
   std::string const& path = request.getPath();
-  std::string const& locationUri = location.getUri();
-
-  std::string fullPath;
-  size_t pos = path.find(locationUri);
-  if (pos != std::string::npos and pos == 0) {
-    fullPath = root + path.substr(locationUri.length());
-  } else {
-    fullPath = root + path;
-  }
+  std::string const& fullPath = request.getFullPath();
 
   if (access(fullPath.c_str(), F_OK) == -1) {
     throw StatusException(

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -22,6 +22,7 @@ class Request {
 
   bool _locationFlag;
   Location _location;
+  std::string _fullPath;
 
  public:
   Request(void);
@@ -38,6 +39,7 @@ class Request {
   std::string const& getBody(void) const;
   Location const& getLocation(void) const;
   bool getLocationFlag(void) const;
+  std::string const& getFullPath(void) const;
 
   std::vector<std::string> const& getHeaderFieldValues(
       std::string const& fieldName) const;
@@ -49,6 +51,7 @@ class Request {
   void storeRequestLine(std::vector<std::string> const& result);
   void storeHeaderField(std::vector<std::string> const& result);
   void storeBody(std::string const& result);
+  void storeFullPath(void);
 
   bool isHeaderFieldNameExists(std::string const& fieldName) const;
   bool isHeaderFieldValueExists(std::string const& fieldName,
@@ -61,6 +64,7 @@ class Request {
   void setPath(std::string const& path);
   void setQuery(std::string const& query);
   void setHttpVersion(std::string const& httpVersion);
+  void setFullPath(std::string const& fullPath);
 
   EHttpMethod matchEHttpMethod(std::string method);
   void splitRequestTarget(std::string& path, std::string& query,

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -333,6 +333,8 @@ void RequestParser::setupBodyParse(void) {
     std::vector<std::string> const& contentLengthValues =
         _request.getHeaderFieldValues("content-length");
     setBodyLength(contentLengthValues[0]);
+
+    if (_bodyLength == 0) _status = DONE;
   }
 }
 

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -35,13 +35,12 @@ enum EParsingStatus RequestParser::getParsingStatus() const { return _status; }
 
 Request const& RequestParser::getRequest() const { return _request; }
 
-// Public Method - setter
-
-void RequestParser::setRequestLocation(Location const& location) {
-  _request.setLocation(location);
-}
-
 // Public Method
+
+void RequestParser::initRequestLocationAndFullPath(Location const& location) {
+  _request.setLocation(location);
+  _request.storeFullPath();
+}
 
 #include <iostream>
 

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -55,7 +55,7 @@ class RequestParser {
   enum EParsingStatus getParsingStatus(void) const;
   Request const& getRequest(void) const;
 
-  void setRequestLocation(Location const& location);
+  void initRequestLocationAndFullPath(Location const& location);
 
   void parse(u_int8_t const* buffer, ssize_t bytesRead);
   void clear();

--- a/http/StaticFileBuilder.cpp
+++ b/http/StaticFileBuilder.cpp
@@ -70,7 +70,7 @@ void StaticFileBuilder::close(void) {
 // 파일 존재 여부를 확인 후 파일 열기
 void StaticFileBuilder::openStaticFile(void) {
   // 파일 경로 제작
-  std::string const& fullPath = makeFullPath();
+  std::string const& fullPath = getRequest().getFullPath();
 
   // 파일 존재 여부 확인
   if (access(fullPath.c_str(), F_OK) == -1) {
@@ -137,26 +137,6 @@ void StaticFileBuilder::readStaticFile(void) {
   }
 }
 
-// 최종 파일 경로를 제작
-// - request와 location 정보를 합쳐 제작
-std::string const StaticFileBuilder::makeFullPath(void) {
-  Request const& request = getRequest();
-  Location const& location = request.getLocation();
-  std::string const& root = location.getRootPath();
-  std::string const& path = request.getPath();
-  std::string const& locationUri = location.getUri();
-
-  std::string fullPath;
-  size_t pos = path.find(locationUri);
-  if (pos != std::string::npos and pos == 0) {
-    fullPath = root + path.substr(locationUri.length());
-  } else {
-    fullPath = root + path;
-  }
-
-  return fullPath;
-}
-
 // body 정보를 받아 response 제작
 void StaticFileBuilder::buildResponseContent(std::string const& body) {
   // Todo: Connection은 request Header 정보 보고 변경되어야 함
@@ -164,7 +144,7 @@ void StaticFileBuilder::buildResponseContent(std::string const& body) {
   _response.setHttpVersion("HTTP/1.1");
   _response.setStatusCode(200);
 
-  std::string const& fullPath = makeFullPath();
+  std::string const& fullPath = getRequest().getFullPath();
   std::string const& mime = Config::findMimeType(fullPath);
   _response.addHeader("Content-Type", mime);
 

--- a/http/StaticFileBuilder.hpp
+++ b/http/StaticFileBuilder.hpp
@@ -35,7 +35,6 @@ class StaticFileBuilder : public AResponseBuilder {
 
   void openStaticFile(void);
   void readStaticFile(void);
-  std::string const makeFullPath(void);
 
   virtual void buildResponseContent(std::string const& body);
 

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -278,7 +278,7 @@ void Connection::setRequestParserLocation(Request const& request) {
   std::string const& host = request.getHeaderFieldValues("host").front();
 
   Location const& location = _manager.getLocation(path, host);
-  _requestParser.setRequestLocation(location);
+  _requestParser.initRequestLocationAndFullPath(location);
 }
 
 // 마지막으로 호출된 시간 업데이트

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -268,6 +268,9 @@ long Connection::getElapsedTime(void) const {
   return std::time(0) - _lastCallTime;
 }
 
+// Connection의 현재 상태가 파라미터 상태와 동일한지 확인
+bool Connection::isSameState(EStatus status) { return (_status == status); }
+
 /**
  * Private method
  */

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -53,6 +53,8 @@ class Connection {
   EStatus getConnectionStatus(void) const;
   long getElapsedTime(void) const;
 
+  bool isSameState(EStatus status);
+
  private:
   static int const BUFFER_SIZE = 1024;
   ServerManager& _manager;

--- a/server/ServerManager.cpp
+++ b/server/ServerManager.cpp
@@ -295,27 +295,27 @@ void ServerManager::handleServerEvent(void) {
 // - 이벤트 처리 과정 중 예외 발생 가능
 void ServerManager::handleReadEvent(int eventFd, Connection& connection) {
   try {
-    if (connection.getConnectionStatus() == Connection::ON_WAIT or
-        connection.getConnectionStatus() == Connection::ON_RECV) {
+    if (connection.isSameState(Connection::ON_WAIT) or
+        connection.isSameState(Connection::ON_RECV)) {
       connection.readSocket();
     }
 
-    if (connection.getConnectionStatus() == Connection::TO_SEND) {
+    if (connection.isSameState(Connection::TO_SEND)) {
       Kqueue::removeReadEvent(eventFd);
 
       connection.selectResponseBuilder();
     }
 
-    if (connection.getConnectionStatus() == Connection::ON_BUILD) {
+    if (connection.isSameState(Connection::ON_BUILD)) {
       connection.buildResponse();
 
-      if (connection.getConnectionStatus() == Connection::ON_SEND) {
+      if (connection.isSameState(Connection::ON_SEND)) {
         int clientFd = connection.getFd();
         Kqueue::addWriteEvent(clientFd);
       }
     }
 
-    if (connection.getConnectionStatus() == Connection::CLOSE) {
+    if (connection.isSameState(Connection::CLOSE)) {
       removeConnection(eventFd);
     }
 
@@ -335,26 +335,26 @@ void ServerManager::handleReadEvent(int eventFd, Connection& connection) {
 // - 이벤트 처리 과정 중 예외 발생 가능
 void ServerManager::handleWriteEvent(int eventFd, Connection& connection) {
   try {
-    if (connection.getConnectionStatus() == Connection::ON_SEND) {
+    if (connection.isSameState(Connection::ON_SEND)) {
       connection.sendResponse();
     }
 
-    if (connection.getConnectionStatus() == Connection::CLOSE) {
+    if (connection.isSameState(Connection::CLOSE)) {
       removeConnection(eventFd);
       return;
     }
 
-    if (connection.getConnectionStatus() == Connection::ON_WAIT) {
+    if (connection.isSameState(Connection::ON_WAIT)) {
       connection.clear();
       Kqueue::removeWriteEvent(eventFd);
       Kqueue::addReadEvent(eventFd);
     }
 
-    if (connection.getConnectionStatus() == Connection::ON_WAIT and
+    if (connection.isSameState(Connection::ON_WAIT) and
         connection.isReadStorageRequired()) {
       Kqueue::removeReadEvent(eventFd);
       connection.readStorage();
-      if (connection.getConnectionStatus() == Connection::TO_SEND) {
+      if (connection.isSameState(Connection::TO_SEND)) {
         Kqueue::addWriteEvent(eventFd);
       } else {
         Kqueue::addReadEvent(eventFd);


### PR DESCRIPTION
## 구현 사항

### content-length가 0일 때 상태 변경 버그 수정
- content-length가 0인 경우 body가 들어올거라고 생각하고 계속 상태가 BODY_CONTENT_LENGTH로 있었음
- 응답을 전송하지 못하고 계속 기다림
- content-length가 0인 경우 DONE으로 상태 변경

### request에 fullPath 저장
- fullPath 멤버 변수 추가
- 생성자, clear 함수 수정 및 getter, setter 구현
- storeFullPath에서 fullPath를 생성한 후 저장
- getLocation 함수에 _locationFlag가 flase일 경우 예외 발생 추가
-  location 할당 시 full path도 함께 저장 
    - setResponseLocation 함수명 initRequestLocationAndFullPath으로 변경
    - initRequestLocationAndFullPath 함수에서 storeFullPath 호출

### request에 저장되어있는 fullPath 이용
- 이전에는 각 builder 내부에서 fullPath를 만들어서 사용
- 현재는 request에 저장된 fullPath를 가지고 와서 사용하도록 변경

### isSameStatus 함수 구현
- connection 객체의 상태를 확인하는 조건문이 반복되어 함수화

## Issue
- close #53