### PR TITLE
[Feat] RedirectBuilder 구현

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ SRCS		= config/Server.cpp \
 			  http/ErrorBuilder.cpp \
 			  http/StaticFileBuilder.cpp \
 			  http/AutoindexBuilder.cpp \
+			  http/RedirectBuilder.cpp \
 			  main.cpp
 				
 

--- a/http/AResponseBuilder.hpp
+++ b/http/AResponseBuilder.hpp
@@ -8,7 +8,7 @@
 
 class AResponseBuilder {
  public:
-  enum EBuilderType { AUTOINDEX, STATIC, ERROR };
+  enum EBuilderType { AUTOINDEX, REDIRECT, STATIC, ERROR };
 
  protected:
   Response _response;

--- a/http/RedirectBuilder.cpp
+++ b/http/RedirectBuilder.cpp
@@ -32,9 +32,39 @@ RedirectBuilder& RedirectBuilder::operator=(RedirectBuilder const& builder) {
  * Public method
  */
 
-int RedirectBuilder::build(void) {}
+int RedirectBuilder::build(void) {
+  generateRedirectPage();
+  return -1;
+}
 
 void RedirectBuilder::close(void) {}
 
-void RedirectBuilder::generateRedirectPage(void) {}
-void RedirectBuilder::buildResponseContent(std::string const& body) {}
+void RedirectBuilder::generateRedirectPage(void) {
+  std::stringstream ss;
+
+  ss << "<!DOCTYPE html> <html> <head> <title> REDIRECT </title> </head> "
+        "<body> <div class= \"container \"> <h1> 301 Moved Permanently </h1>";
+
+  ss << "<p>The document has moved <a href=\"" << _redirectUri
+     << "\"> here</a>.</p> </body> </html>";
+
+  std::string const body = ss.str();
+  buildResponseContent(body);
+  _isDone = true;
+}
+
+// body 정보를 받아 response 제작
+void RedirectBuilder::buildResponseContent(std::string const& body) {
+  _response.setHttpVersion("HTTP/1.1");
+  _response.setStatusCode(301);
+
+  _response.addHeader("Content-Type", "text/html");
+  _response.addHeader("Content-Length", Util::itos(body.size()));
+  _response.addHeader("Location", _redirectUri);
+
+  _response.addHeader("Connection", "keep-alive");
+
+  _response.appendBody(body);
+
+  _response.makeResponseContent();
+}

--- a/http/RedirectBuilder.cpp
+++ b/http/RedirectBuilder.cpp
@@ -1,0 +1,40 @@
+#include "RedirectBuilder.hpp"
+
+/**
+ * Constructor & Destructor
+ */
+
+RedirectBuilder::RedirectBuilder(Request const& request,
+                                 std::string const& redirectUri)
+    : AResponseBuilder(REDIRECT, request), _redirectUri(redirectUri) {}
+
+RedirectBuilder::RedirectBuilder(RedirectBuilder const& builder)
+    : AResponseBuilder(builder), _redirectUri(builder._redirectUri) {}
+
+RedirectBuilder::~RedirectBuilder(void) {}
+
+/**
+ * Operator Overloading
+ */
+
+RedirectBuilder& RedirectBuilder::operator=(RedirectBuilder const& builder) {
+  if (this != &builder) {
+    _response = builder._response;
+    _isDone = builder._isDone;
+    setRequest(builder.getRequest());
+    setType(builder.getType());
+    _redirectUri = builder._redirectUri;
+  }
+  return *this;
+}
+
+/**
+ * Public method
+ */
+
+int RedirectBuilder::build(void) {}
+
+void RedirectBuilder::close(void) {}
+
+void RedirectBuilder::generateRedirectPage(void) {}
+void RedirectBuilder::buildResponseContent(std::string const& body) {}

--- a/http/RedirectBuilder.hpp
+++ b/http/RedirectBuilder.hpp
@@ -1,0 +1,30 @@
+#ifndef __REDIRECT_BUILDER_HPP__
+#define __REDIRECT_BUILDER_HPP__
+
+#include <sstream>
+
+#include "../utils/StatusException.hpp"
+#include "AResponseBuilder.hpp"
+
+class RedirectBuilder : public AResponseBuilder {
+ private:
+  std::string _redirectUri;
+
+ public:
+  RedirectBuilder(Request const& request, std::string const& redirectUri);
+  RedirectBuilder(RedirectBuilder const& builder);
+  virtual ~RedirectBuilder(void);
+
+  RedirectBuilder& operator=(RedirectBuilder const& builder);
+
+  virtual int build(void);
+  virtual void close(void);
+
+ private:
+  RedirectBuilder(void);
+
+  void generateRedirectPage(void);
+  virtual void buildResponseContent(std::string const& body);
+};
+
+#endif

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -139,6 +139,7 @@ void Connection::selectResponseBuilder(void) {
     }
   } else {
     _responseBuilder = new StaticFileBuilder(request);
+    // _responseBuilder = new RedirectBuilder(request, path + '/');
   }
   setStatus(ON_BUILD);
 }

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -131,6 +131,12 @@ void Connection::selectResponseBuilder(void) {
   std::string const& path = request.getPath();
   Location const& location = request.getLocation();
 
+  if (location.isRedirectBlock()) {
+    _responseBuilder = new RedirectBuilder(request, location.getRedirectUri());
+    setStatus(ON_BUILD);
+    return;
+  }
+
   if (path.back() == '/') {
     if (location.isAutoIndex()) {
       _responseBuilder = new AutoindexBuilder(request);
@@ -139,7 +145,6 @@ void Connection::selectResponseBuilder(void) {
     }
   } else {
     _responseBuilder = new StaticFileBuilder(request);
-    // _responseBuilder = new RedirectBuilder(request, path + '/');
   }
   setStatus(ON_BUILD);
 }

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -7,6 +7,7 @@
 #include "../http/AResponseBuilder.hpp"
 #include "../http/AutoindexBuilder.hpp"
 #include "../http/ErrorBuilder.hpp"
+#include "../http/RedirectBuilder.hpp"
 #include "../http/Request.hpp"
 #include "../http/RequestParser.hpp"
 #include "../http/StaticFileBuilder.hpp"


### PR DESCRIPTION
## 구현 사항

### RedirectBuilder 클래스
- redirectUri 멤버 변수 추가
- REDIRECT 타입 추가

### RedirectBuilder build 함수 구현
- 301 상태 코드로 응답
  - 클라이언트에 따라 메서드를 재정의한다고 함 (크롬 동작 확인 필요)
  - postman에서 실행 결과 POST, DELETE 메서드가 GET으로 재작성
- 응답에 `Location` 헤더 내부에 리다이렉션 할 URI(`redirectUri`) 포함
- 응답 페이로드(body)에는 html 포함
- 사용자 에이전트(브라우저 등)가 리다이렉트를 자동으로 처리하지 않는 경우를 대비한 것

### 실행 결과

**[ 응답 생성 예시 ]**

```
HTTP/1.1 301 Moved Permanently
Connection: keep-alive
Content-Length: 203
Content-Type: text/html
Location: /image/

<!DOCTYPE html> <html> <head> <title> REDIRECT </title> </head> <body> <div class= "container ">
<h1> 301 Moved Permanently </h1>
<p>The document has moved <a href="/image/"> here</a>.</p> 
</body> </html>
``` 

**[ 응답 페이로드 html 파일 결과 ]**
- 정적 파일로 저장했을 때 이렇게 뜸
- 실제로는 클라이언트가 Location에 추가된 uri로 요청 전송

<img width="370" alt="Screen Shot 2024-01-24 at 2 07 13 PM" src="https://github.com/wonyangs/webserv/assets/44529556/7d64bca7-8efb-4ffa-b939-3fbdb56e6a5e">
