### PR TITLE
[Feat] CGI builder 제작을 위한 사전 작업

### DIFF
--- a/config/Location.cpp
+++ b/config/Location.cpp
@@ -13,6 +13,7 @@ Location::Location(std::string const& uri, std::string const& rootPath,
       _indexFile(indexFile),
       _maxBodySize(DEFAULT_MAX_BODY_SIZE),
       _autoIndex(false),
+      _cgiFlag(false),
       _hasAllowMethodField(false),
       _hasRedirectField(false) {}
 
@@ -33,6 +34,12 @@ Location& Location::operator=(Location const& location) {
     this->_allowMethods = location._allowMethods;
     this->_autoIndex = location._autoIndex;
     this->_redirectUri = location._redirectUri;
+
+    this->_cgiFlag = location._cgiFlag;
+    this->_cgiExtention = location._cgiExtention;
+    this->_cgiPath = location._cgiPath;
+    this->_uploadPath = location._uploadPath;
+
     this->_hasAllowMethodField = location._hasAllowMethodField;
     this->_hasRedirectField = location._hasRedirectField;
   }
@@ -88,6 +95,27 @@ void Location::setRedirectUri(std::string const& path) {
   _redirectUri = path;
 }
 
+// CGI extention 설정
+// - 한 번이라도 메서드가 호출된 경우 cgi를 가지고 있다고 판단
+void Location::setCgiExtention(std::string const& extention) {
+  _cgiExtention = extention;
+  _cgiFlag = true;
+}
+
+// CGI path 설정
+// - 한 번이라도 메서드가 호출된 경우 cgi를 가지고 있다고 판단
+void Location::setCgiPath(std::string const& cgiPath) {
+  _cgiPath = cgiPath;
+  _cgiFlag = true;
+}
+
+// 파일 upload 디렉토리 설정
+// - 한 번이라도 메서드가 호출된 경우 cgi를 가지고 있다고 판단
+void Location::setUploadDir(std::string const& dirPath) {
+  _uploadPath = dirPath;
+  _cgiFlag = true;
+}
+
 // Public Method - getter
 
 std::string const& Location::getUri(void) const { return _uri; }
@@ -141,4 +169,34 @@ std::string const& Location::getRedirectUri(void) const {
         "[1104] Location: getRedirectUri - doesn't have a uri");
   }
   return _redirectUri;
+}
+
+// CGI 정보를 가지고 있는지 여부 반환
+bool Location::hasCgiInfo(void) const { return _cgiFlag; }
+
+// CGI extention 반환
+// - CGI 정보가 설정되어 있지 않은데 호출된 경우 예외 발생
+std::string const& Location::getCgiExtention(void) const {
+  if (_cgiFlag == false) {
+    throw std::runtime_error("[1105] Location: getCgiExtention - no cgi info");
+  }
+  return _cgiExtention;
+}
+
+// CGI 경로 반환
+// - CGI 정보가 설정되어 있지 않은데 호출된 경우 예외 발생
+std::string const& Location::getCgiPath(void) const {
+  if (_cgiFlag == false) {
+    throw std::runtime_error("[1106] Location: getCgiPath - no cgi info");
+  }
+  return _cgiPath;
+}
+
+// 파일 업로드 디렉토리 경로 반환
+// - CGI 정보가 설정되어 있지 않은데 호출된 경우 예외 발생
+std::string const& Location::getUploadDirPath(void) const {
+  if (_cgiFlag == false) {
+    throw std::runtime_error("[1107] Location: getUploadDirPath - no cgi info");
+  }
+  return _uploadPath;
 }

--- a/config/Location.hpp
+++ b/config/Location.hpp
@@ -22,6 +22,11 @@ class Location {
   bool _autoIndex;
   std::string _redirectUri;
 
+  bool _cgiFlag;
+  std::string _cgiExtention;
+  std::string _cgiPath;
+  std::string _uploadPath;
+
  public:
   Location(void);
   Location(std::string const& uri, std::string const& rootPath,
@@ -37,6 +42,9 @@ class Location {
   void addAllowMethod(EHttpMethod method);
   void setAutoIndex(bool setting);
   void setRedirectUri(std::string const& path);
+  void setCgiExtention(std::string const& extention);
+  void setCgiPath(std::string const& cgiPath);
+  void setUploadDir(std::string const& dirPath);
 
   // getter
   std::string const& getUri(void) const;
@@ -49,6 +57,10 @@ class Location {
   bool isAutoIndex(void) const;
   bool isRedirectBlock(void) const;
   std::string const& getRedirectUri(void) const;
+  bool hasCgiInfo(void) const;
+  std::string const& getCgiExtention(void) const;
+  std::string const& getCgiPath(void) const;
+  std::string const& getUploadDirPath(void) const;
 
  private:
   static int const DEFAULT_MAX_BODY_SIZE = 6000;

--- a/core/Event.cpp
+++ b/core/Event.cpp
@@ -16,6 +16,9 @@ Event::Event(struct kevent const& event) {
     _type = READ;
   } else if (event.filter == EVFILT_WRITE) {
     _type = WRITE;
+  } else if (event.filter == EVFILT_PROC) {
+    _type = PROC;
+    _fd = -_fd;
   } else {
     throw std::runtime_error("[3101] Event: Event - undefine event type");
   }
@@ -51,6 +54,4 @@ Event::EventType Event::getType(void) const {
 
 // 잘못된 이벤트인지 여부 반환
 // - kevent에서 반환된 이벤트가 없을 경우 올바르지 않은 이벤트가 반환될 수 있음
-bool Event::isInvalid(void) const {
-  return (_fd < 0);
-}
+bool Event::isInvalid(void) const { return (_fd < 0); }

--- a/core/Event.hpp
+++ b/core/Event.hpp
@@ -8,7 +8,12 @@
 // kevent 구조체 정보를 관리하는 클래스
 class Event {
  public:
-  enum EventType { READ = EVFILT_READ, WRITE = EVFILT_WRITE };
+  enum EventType {
+    READ = EVFILT_READ,
+    WRITE = EVFILT_WRITE,
+    PROC = EVFILT_PROC,
+    NONE
+  };
 
  private:
   int _fd;

--- a/core/Kqueue.hpp
+++ b/core/Kqueue.hpp
@@ -21,8 +21,11 @@ class Kqueue {
 
   static void addReadEvent(int fd);
   static void addWriteEvent(int fd);
+  static void addProcessEvent(int pid);
+
   static void removeReadEvent(int fd);
   static void removeWriteEvent(int fd);
+  static void removeProcessEvent(int pid);
 
   static void removeAllEvents(int fd);
 
@@ -30,7 +33,12 @@ class Kqueue {
 
  private:
   enum EEventAction { ADD, REMOVE };
-  enum EEventType { NO_EVENT = 0, READ_EVENT = 1 << 0, WRITE_EVENT = 1 << 1 };
+  enum EEventType {
+    NO_EVENT = 0,
+    READ_EVENT = 1 << 0,
+    WRITE_EVENT = 1 << 1,
+    PROC_EVENT = 1 << 2
+  };
 
   static void updateEventStatus(int fd, EEventType event, EEventAction action);
 

--- a/http/AResponseBuilder.hpp
+++ b/http/AResponseBuilder.hpp
@@ -2,7 +2,9 @@
 #define __A_RESPONSE_BUILDER_HPP__
 
 #include <string>
+#include <vector>
 
+#include "../core/Event.hpp"
 #include "Request.hpp"
 #include "Response.hpp"
 
@@ -29,7 +31,7 @@ class AResponseBuilder {
   Response& getResponse(void);
   bool isDone(void) const;
 
-  virtual int build(void) = 0;
+  virtual std::vector<int> const build(Event::EventType type) = 0;
   virtual void close(void) = 0;
 
  protected:

--- a/http/AutoindexBuilder.cpp
+++ b/http/AutoindexBuilder.cpp
@@ -32,7 +32,8 @@ AutoindexBuilder& AutoindexBuilder::operator=(AutoindexBuilder const& builder) {
 
 // autoindex page 제작이 가능한지 확인 후 가능하다면 제작
 // - 가능한 경우가 아니라면 예외 발생
-int AutoindexBuilder::build(void) {
+std::vector<int> const AutoindexBuilder::build(Event::EventType type) {
+  (void)type;
   Request const& request = getRequest();
   EHttpMethod const& method = request.getMethod();
 
@@ -79,7 +80,7 @@ int AutoindexBuilder::build(void) {
     throw std::runtime_error("[5204] AutoindexBuilder: build - opendir failed");
 
   generateAutoindexPage(fullPath, path, directory);
-  return -1;
+  return std::vector<int>();
 }
 
 void AutoindexBuilder::close(void) {}

--- a/http/AutoindexBuilder.hpp
+++ b/http/AutoindexBuilder.hpp
@@ -20,7 +20,7 @@ class AutoindexBuilder : public AResponseBuilder {
 
   AutoindexBuilder& operator=(AutoindexBuilder const& builder);
 
-  virtual int build(void);
+  virtual std::vector<int> const build(Event::EventType type);
   virtual void close(void);
 
  private:

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -58,17 +58,19 @@ ErrorBuilder& ErrorBuilder::operator=(ErrorBuilder const& builder) {
  */
 
 // 새로운 이벤트가 등록되었다면 해당 fd 반환, 아니라면 -1 반환
-int ErrorBuilder::build(void) {
+std::vector<int> const ErrorBuilder::build(Event::EventType type) {
+  (void)type;
   Request const& request = getRequest();
 
   if (_recursiveFlag == false and request.getLocationFlag()) {
     Location const& location = request.getLocation();
     if (location.hasErrorPage(_statusCode)) {
-      return readStatusCodeFile(location);
+      int fd = readStatusCodeFile(location);
+      return std::vector<int>(1, fd);
     }
   }
   generateDefaultPage();
-  return -1;
+  return std::vector<int>();
 }
 
 void ErrorBuilder::close(void) {

--- a/http/ErrorBuilder.hpp
+++ b/http/ErrorBuilder.hpp
@@ -32,7 +32,7 @@ class ErrorBuilder : public AResponseBuilder {
 
   ErrorBuilder& operator=(ErrorBuilder const& builder);
 
-  virtual int build(void);
+  virtual std::vector<int> const build(Event::EventType type);
   virtual void close(void);
 
  private:

--- a/http/RedirectBuilder.cpp
+++ b/http/RedirectBuilder.cpp
@@ -32,9 +32,10 @@ RedirectBuilder& RedirectBuilder::operator=(RedirectBuilder const& builder) {
  * Public method
  */
 
-int RedirectBuilder::build(void) {
+std::vector<int> const RedirectBuilder::build(Event::EventType type) {
+  (void)type;
   generateRedirectPage();
-  return -1;
+  return std::vector<int>();
 }
 
 void RedirectBuilder::close(void) {}

--- a/http/RedirectBuilder.hpp
+++ b/http/RedirectBuilder.hpp
@@ -17,7 +17,7 @@ class RedirectBuilder : public AResponseBuilder {
 
   RedirectBuilder& operator=(RedirectBuilder const& builder);
 
-  virtual int build(void);
+  virtual std::vector<int> const build(Event::EventType type);
   virtual void close(void);
 
  private:

--- a/http/StaticFileBuilder.cpp
+++ b/http/StaticFileBuilder.cpp
@@ -43,16 +43,17 @@ StaticFileBuilder& StaticFileBuilder::operator=(
  * Public method
  */
 
-int StaticFileBuilder::build(void) {
+std::vector<int> const StaticFileBuilder::build(Event::EventType type) {
+  (void)type;
   // 첫 번째 호출 시 파일을 열음
   if (_fileFd == -1) {
     openStaticFile();
-    return _fileFd;
+    return std::vector<int>(1, _fileFd);
   }
 
   // 두 번째 호출부터는 파일을 읽음
   readStaticFile();
-  return -1;
+  return std::vector<int>();
 }
 
 void StaticFileBuilder::close(void) {

--- a/http/StaticFileBuilder.hpp
+++ b/http/StaticFileBuilder.hpp
@@ -27,7 +27,7 @@ class StaticFileBuilder : public AResponseBuilder {
 
   StaticFileBuilder& operator=(StaticFileBuilder const& builder);
 
-  virtual int build(void);
+  virtual std::vector<int> const build(Event::EventType type);
   virtual void close(void);
 
  private:

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -19,7 +19,6 @@ Connection::Connection(int fd, ServerManager& manager)
       _status(ON_WAIT),
       _requestParser(),
       _responseBuilder(NULL),
-      _builderFd(-1),
       _manager(manager) {}
 
 Connection::Connection(Connection const& connection)
@@ -40,7 +39,7 @@ Connection& Connection::operator=(Connection const& connection) {
     _status = connection._status;
     _requestParser = connection._requestParser;
     _responseBuilder = connection._responseBuilder;
-    _builderFd = connection._builderFd;
+    _builderFds = connection._builderFds;
     _manager = connection._manager;
   }
   return *this;
@@ -144,21 +143,21 @@ void Connection::selectResponseBuilder(void) {
 }
 
 // HTTP 응답 만들기
-void Connection::buildResponse() {
-  int builderFd = _responseBuilder->build();
+void Connection::buildResponse(Event::EventType eventType) {
+  std::vector<int> const& builderFds = _responseBuilder->build(eventType);
 
-  if (builderFd != -1) {
-    _manager.addManagedFd(builderFd, _fd);
-    _builderFd = builderFd;
+  if (builderFds.size() != 0) {
+    for (std::vector<int>::const_iterator it = builderFds.begin();
+         it != builderFds.end(); ++it) {
+      _manager.addManagedFd(*it, _fd);
+    }
+    _builderFds = builderFds;
   }
 
   if (_responseBuilder->isDone()) {
     setStatus(ON_SEND);
     _responseBuilder->close();
-    if (_builderFd != -1) {
-      _manager.removeManagedFd(_builderFd);
-      _builderFd = -1;
-    }
+    removeAllBuilderFd();
   }
 }
 
@@ -208,6 +207,8 @@ void Connection::sendResponse(void) {
 void Connection::resetResponseBuilder(int code) {
   Kqueue::removeAllEvents(_fd);
 
+  removeAllBuilderFd();
+
   if (_responseBuilder != NULL) {
     delete _responseBuilder;
     _responseBuilder = NULL;
@@ -216,7 +217,7 @@ void Connection::resetResponseBuilder(int code) {
   _responseBuilder = new ErrorBuilder(_requestParser.getRequest(), code);
   setStatus(ON_BUILD);
 
-  buildResponse();
+  buildResponse(Event::NONE);
   if (_status == Connection::ON_SEND) {
     Kqueue::addWriteEvent(_fd);
   }
@@ -224,6 +225,8 @@ void Connection::resetResponseBuilder(int code) {
 
 void Connection::resetResponseBuilder(void) {
   Kqueue::removeAllEvents(_fd);
+
+  removeAllBuilderFd();
 
   if (_responseBuilder != NULL) {
     delete _responseBuilder;
@@ -233,7 +236,7 @@ void Connection::resetResponseBuilder(void) {
   _responseBuilder = new ErrorBuilder();
   setStatus(ON_BUILD);
 
-  buildResponse();
+  buildResponse(Event::NONE);
   if (_status == Connection::ON_SEND) {
     Kqueue::addWriteEvent(_fd);
   }
@@ -279,6 +282,17 @@ void Connection::setRequestParserLocation(Request const& request) {
 
   Location const& location = _manager.getLocation(path, host);
   _requestParser.setRequestLocation(location);
+}
+
+// builder에서 사용하는 모든 fd 정보를 제거
+void Connection::removeAllBuilderFd(void) {
+  if (_builderFds.size() != 0) {
+    for (std::vector<int>::const_iterator it = _builderFds.begin();
+         it != _builderFds.end(); ++it) {
+      _manager.removeManagedFd(*it);
+    }
+    _builderFds.clear();
+  }
 }
 
 // 마지막으로 호출된 시간 업데이트

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -3,6 +3,7 @@
 
 #include <ctime>
 #include <string>
+#include <vector>
 
 #include "../http/AResponseBuilder.hpp"
 #include "../http/AutoindexBuilder.hpp"
@@ -26,7 +27,7 @@ class Connection {
 
   RequestParser _requestParser;
   AResponseBuilder* _responseBuilder;
-  int _builderFd;
+  std::vector<int> _builderFds;
 
  public:
   Connection(int fd, ServerManager& manager);
@@ -40,7 +41,7 @@ class Connection {
   bool isReadStorageRequired(void);
 
   void selectResponseBuilder(void);
-  void buildResponse(void);
+  void buildResponse(Event::EventType eventType);
   void sendResponse(void);
 
   void resetResponseBuilder(int code);
@@ -59,6 +60,7 @@ class Connection {
 
   void parseRequest(u_int8_t const* buffer, ssize_t bytesRead);
   void setRequestParserLocation(Request const& request);
+  void removeAllBuilderFd(void);
 
   void updateLastCallTime(void);
   void setStatus(EStatus status);

--- a/server/ServerManager.hpp
+++ b/server/ServerManager.hpp
@@ -54,11 +54,13 @@ class ServerManager {
   bool hasConnectionFd(int fd) const;
 
   bool hasManagedFd(int fd) const;
-  void removeAllManagedFd(int managedFd);
+  void removeAllManagedFd(int ownerFd);
 
   void handleServerEvent(void);
   void handleReadEvent(int eventFd, Connection& connection);
   void handleWriteEvent(int eventFd, Connection& connection);
+  void handleProcessEvent(Connection& connection);
+
   Connection& findConnection(int eventFd);
 
   ServerManager(void);


### PR DESCRIPTION
### Location

- cgi 관련 멤버 변수 및 메서드 추가

### Kqueue & Event

- Kqueue에 프로세스 이벤트를 위한 메서드 구현
- Event 타입에 프로세스 이벤트 추가
- 기본 Event 객체를 넘겨주기 위한 NONE 이벤트 추가

### AResponseBuilder

- 여러개의 fd를 반환해야 하는 경우가 생겨 vector<int>형태로 반환하도록 수정
- Event를 인자로 받을 수 있도록 수정
- type을 쓰지 않는 경우 (void)type을 이용하여 -WWW 플래그 회피

## builderFd 수정

### Connection
- builder에서 여러 개의 fd가 반환됨에 따라 반환된 fd들을 vector 형태로 가지고 있도록 수정
- 반환된 vector의 크기가 0인 경우 이벤트 등록이 없다고 판단
- 반환된 vector의 크기가 0보다 큰 경우 vector안에 있는 이벤트들을 manager에 모두 등록
- fd 관리가 필요 없어진 경우 vector 안에 있는 이벤트 전부 삭제
- resetResponseBuilder 메서드에서 builder fd를 삭제하지 않던 오류 수정

### ServerManager
- PROC 이벤트를 처리하는 부분 추가
- WRITE 이벤트를 받았을 때 ON_BUILD인 경우 build를 하도록 수정

## RedirectionBuilder

- 위 변경사항 적용
