### PR TITLE
[Feat] request 값 유효성 검사

### DIFF
--- a/http/AutoindexBuilder.cpp
+++ b/http/AutoindexBuilder.cpp
@@ -38,9 +38,8 @@ std::vector<int> const AutoindexBuilder::build(Event::EventType type) {
   EHttpMethod const& method = request.getMethod();
 
   if (method != HTTP_GET and method != HTTP_POST) {
-    throw StatusException(
-        HTTP_NOT_ALLOWED,
-        "[5200] AutoindexBuilder: build - http method not allowed");
+    throw StatusException(HTTP_FORBIDDEN,
+                          "[5200] AutoindexBuilder: build - forbidden");
   }
 
   Location const& location = request.getLocation();

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -58,7 +58,8 @@ ErrorBuilder& ErrorBuilder::operator=(ErrorBuilder const& builder) {
  */
 
 bool ErrorBuilder::isConnectionClose(void) const {
-  if (_statusCode / 100 == 5 or _statusCode == 400) return true;
+  if (_statusCode / 100 == 5 or _statusCode == 400 or _statusCode == 413)
+    return true;
 
   Request const& request = getRequest();
   return request.isConnectionClose();

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -104,7 +104,7 @@ int ErrorBuilder::readStatusCodeFile(Location const& location) {
   }
 
   // 파일 읽기
-  u_int8_t buffer[BUFFER_SIZE];
+  octet_t buffer[BUFFER_SIZE];
   memset(buffer, 0, BUFFER_SIZE);
   ssize_t bytesRead = read(_fileFd, buffer, sizeof(buffer));
   _readIndex += bytesRead;

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -181,7 +181,31 @@ void ErrorBuilder::buildResponseContent(std::string const& body) {
   isConnectionClose() ? _response.addHeader("Connection", "close")
                       : _response.addHeader("Connection", "keep-alive");
 
+  if (_statusCode == 405) _response.addHeader("Allow", makeAllowHeaderValue());
+
   _response.appendBody(body);
 
   _response.makeResponseContent();
+}
+
+std::string ErrorBuilder::makeAllowHeaderValue(void) {
+  Location const& location = getRequest().getLocation();
+
+  std::stringstream ss;
+  bool isFirst = true;
+
+  if (location.isAllowMethod(HTTP_GET)) {
+    ss << "GET";
+    isFirst = false;
+  }
+  if (location.isAllowMethod(HTTP_POST)) {
+    ss << (isFirst ? "POST" : ", POST");
+    isFirst = false;
+  }
+  if (location.isAllowMethod(HTTP_DELETE)) {
+    ss << (isFirst ? "DELETE" : ", DELETE");
+    isFirst = false;
+  }
+
+  return ss.str();
 }

--- a/http/ErrorBuilder.hpp
+++ b/http/ErrorBuilder.hpp
@@ -46,6 +46,7 @@ class ErrorBuilder : public AResponseBuilder {
   void generateDefaultPage(void);
 
   virtual void buildResponseContent(std::string const& body);
+  std::string makeAllowHeaderValue(void);
 };
 
 #endif

--- a/http/ErrorBuilder.hpp
+++ b/http/ErrorBuilder.hpp
@@ -9,6 +9,7 @@
 
 #include "../core/Kqueue.hpp"
 #include "../core/Socket.hpp"
+#include "../utils/Config.hpp"
 #include "../utils/StatusException.hpp"
 #include "../utils/Util.hpp"
 #include "AResponseBuilder.hpp"
@@ -22,7 +23,7 @@ class ErrorBuilder : public AResponseBuilder {
   off_t _fileSize;
   off_t _readIndex;
 
-  std::vector<u_int8_t> _storageBuffer;
+  std::vector<octet_t> _storageBuffer;
 
  public:
   ErrorBuilder(void);

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -79,6 +79,7 @@ bool Request::getLocationFlag(void) const { return _locationFlag; }
 
 std::string const& Request::getFullPath(void) const { return _fullPath; }
 
+// host, connection의 field-value는 소문자로 저장되어 있음
 std::string const& Request::getHeaderFieldValues(
     std::string const& fieldName) const {
   if (isHeaderFieldNameExists(fieldName) == false) {
@@ -145,11 +146,19 @@ void Request::storeRequestTarget(std::string const& requestTarget) {
 
 // Header field 저장
 // - result 배열에는 fieldName과 fieldValue가 순서대로 저장되어 있다고 가정
+// - Request 객체에 이미 존재하는 field-name일 경우 예외 발생
 void Request::storeHeaderField(std::vector<std::string> const& result) {
   int const fieldNameIndex = 0, fieldValueIndex = 1;
 
   std::string const& fieldName = result[fieldNameIndex];
   std::string const& fieldValue = result[fieldValueIndex];
+
+  if (isHeaderFieldNameExists(fieldName)) {
+    throw StatusException(
+        HTTP_BAD_REQUEST,
+        "[2202] Request: storeHeaderField - duplicate field-name");
+  }
+
   _header.insert(std::pair<std::string, std::string>(fieldName, fieldValue));
 
   if (fieldName == "connection" and fieldValue == "close")
@@ -179,6 +188,7 @@ void Request::storeFullPath(void) {
 }
 
 // 해당 헤더 field-name의 존재를 확인하는 함수
+// - field-name은 소문자로 저장되어 있음
 bool Request::isHeaderFieldNameExists(std::string const& fieldName) const {
   return (_header.find(fieldName) != _header.end());
 }

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -209,6 +209,19 @@ void Request::setPath(std::string const& path) { _path = path; }
 void Request::setQuery(std::string const& query) { _query = query; }
 
 void Request::setHttpVersion(std::string const& httpVersion) {
+  if (isValidHTTPVersionFormat(httpVersion) == false) {
+    throw StatusException(
+        HTTP_BAD_REQUEST,
+        "[2006] Request: setHttpVersion - invalid format: " + httpVersion);
+  }
+
+  if (httpVersion != "HTTP/1.0" and httpVersion != "HTTP/1.1") {
+    throw StatusException(
+        HTTP_VERSION_NOT_SUPPORTED,
+        "[2007] Request: setHttpVersion - version not supported: " +
+            httpVersion);
+  }
+
   _httpVersion = httpVersion;
   if (_httpVersion == "HTTP/1.0") _isConnectionClose = true;
 }
@@ -265,6 +278,16 @@ bool Request::isValidRequestTarget(std::string const& requestTarget) {
 
     return false;
   }
+  return true;
+}
+
+bool Request::isValidHTTPVersionFormat(std::string const& httpVersion) {
+  if (httpVersion.size() != 8) return false;
+  if (httpVersion.substr(0, 5) != "HTTP/") return false;
+  if (isdigit(httpVersion[5]) == false or httpVersion[6] != '.' or
+      isdigit(httpVersion[7]) == false)
+    return false;
+
   return true;
 }
 

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -130,6 +130,12 @@ void Request::storeRequestTarget(std::string const& requestTarget) {
         "[2103] Request: storeRequestTarget - path is too long");
   }
 
+  if (isValidRequestTarget(requestTarget) == false) {
+    throw StatusException(
+        HTTP_BAD_REQUEST,
+        "[2104] Request: storeRequestTarget - request Target is invalid");
+  }
+
   std::string path, query;
   splitRequestTarget(path, query, requestTarget);
 
@@ -235,6 +241,31 @@ void Request::splitRequestTarget(std::string& path, std::string& query,
 
   path = requestTarget;
   query = "";
+}
+
+bool Request::isHex(char ch) {
+  return ('0' <= ch and ch <= '9') or ('a' <= ch and ch <= 'f') or
+         ('A' <= ch and ch <= 'F');
+}
+
+bool Request::isValidRequestTarget(std::string const& requestTarget) {
+  size_t size = requestTarget.size();
+  if (requestTarget.size() < 1 or requestTarget.front() != '/') return false;
+
+  std::string const& others = "-._~!$&'()*+,;=:@/";
+  for (size_t i = 0; i < size; i++) {
+    char ch = requestTarget[i];
+
+    if (isalpha(ch) or isdigit(ch) or others.find(ch) != std::string::npos)
+      continue;
+
+    if (ch == '%' and i + 2 < size) {
+      if (isHex(requestTarget[i + 1]) and isHex(requestTarget[i + 2])) continue;
+    }
+
+    return false;
+  }
+  return true;
 }
 
 // 인자로 받은 16진수를 문자(char)로 변경하여 반환

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -213,7 +213,7 @@ EHttpMethod Request::matchEHttpMethod(std::string method) {
   if (method == "GET") return HTTP_GET;
   if (method == "POST") return HTTP_POST;
   if (method == "DELETE") return HTTP_DELETE;
-  throw StatusException(HTTP_NOT_ALLOWED,
+  throw StatusException(HTTP_NOT_IMPLEMENTED,
                         "[2101] Request: matchEHttpMethod - invalid method");
 }
 

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -1,6 +1,7 @@
 #ifndef __REQUEST_HPP__
 #define __REQUEST_HPP__
 
+#include <cctype>
 #include <map>
 #include <string>
 #include <vector>
@@ -52,6 +53,7 @@ class Request {
   void print(void) const;  // debug
 
   void storeRequestLine(std::vector<std::string> const& result);
+  void storeRequestTarget(std::string const& requestTarget);
   void storeHeaderField(std::vector<std::string> const& result);
   void storeBody(std::string const& result);
   void storeFullPath(void);
@@ -71,6 +73,9 @@ class Request {
   EHttpMethod matchEHttpMethod(std::string method);
   void splitRequestTarget(std::string& path, std::string& query,
                           const std::string& requestTarget);
+
+  char hexToChar(std::string const& hexStr);
+  std::string pctDecode(std::string const& str);
 };
 
 #endif

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -25,8 +25,6 @@ class Request {
   Location _location;
   std::string _fullPath;
 
-  bool _isConnectionClose;
-
  public:
   Request(void);
   Request(Request const& request);
@@ -43,8 +41,8 @@ class Request {
   Location const& getLocation(void) const;
   bool getLocationFlag(void) const;
   std::string const& getFullPath(void) const;
-
   std::string const& getHeaderFieldValues(std::string const& fieldName) const;
+  std::string const getHost(void) const;
 
   void setLocation(Location const& location);
 

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -74,6 +74,8 @@ class Request {
   void splitRequestTarget(std::string& path, std::string& query,
                           const std::string& requestTarget);
 
+  bool isHex(char ch);
+  bool isValidRequestTarget(std::string const& requestTarget);
   char hexToChar(std::string const& hexStr);
   std::string pctDecode(std::string const& str);
 };

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -76,6 +76,7 @@ class Request {
 
   bool isHex(char ch);
   bool isValidRequestTarget(std::string const& requestTarget);
+  bool isValidHTTPVersionFormat(std::string const& httpVersion);
   char hexToChar(std::string const& hexStr);
   std::string pctDecode(std::string const& str);
 };

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -470,6 +470,12 @@ bool RequestParser::isBodyChunk(void) {
 // - 이 외의 경우 DONE
 EParsingStatus RequestParser::checkBodyParsingStatus() {
   if (isBodyChunk()) {
+    if (_request.isHeaderFieldNameExists("content-length")) {
+      throw StatusException(
+          HTTP_BAD_REQUEST,
+          "[2205] RequestParser: checkBodyParsingStatus - Content-Length field "
+          "cannot exist when Transfer-Encoding field is included.");
+    }
     return BODY_CHUNKED;
   }
 

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -54,6 +54,11 @@ void RequestParser::parse(u_int8_t const* buffer, ssize_t bytesRead) {
     setupBodyParse();
 
     if (_status == DONE) return;
+    if (_request.getMethod() != HTTP_POST) {
+      throw StatusException(
+          HTTP_BAD_REQUEST,
+          "[2008] RequestParser: parse - only post methods can handle payload");
+    }
   }
 
   for (size_t i = 0; i < _storageBuffer.size(); i++) {

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -49,7 +49,7 @@ void RequestParser::initRequestLocationAndFullPath(Location const& location) {
 // - 이후 buffer 값 파싱
 // - 파싱 도중 HEADER_FIELD_END 또는 DONE이 되었을 경우,
 //   남은 octets은 _storageBuffer에 저장
-void RequestParser::parse(u_int8_t const* buffer, ssize_t bytesRead) {
+void RequestParser::parse(octet_t const* buffer, ssize_t bytesRead) {
   if (_status == HEADER_FIELD_END) {
     setupBodyParse();
 
@@ -157,9 +157,9 @@ void RequestParser::setChunkSize(std::string const& chunkSizeString) {
 
 // storageBuffer 저장
 // - 남아있는 값에서 startIdx 이전 값들 삭제 후 buffer 값 추가
-void RequestParser::setStorageBuffer(size_t startIdx, u_int8_t const* buffer,
+void RequestParser::setStorageBuffer(size_t startIdx, octet_t const* buffer,
                                      ssize_t bytesRead) {
-  std::vector<u_int8_t> tmp;
+  std::vector<octet_t> tmp;
 
   for (size_t i = startIdx; i < _storageBuffer.size(); i++) {
     tmp.push_back(_storageBuffer[i]);
@@ -175,7 +175,7 @@ void RequestParser::setStorageBuffer(size_t startIdx, u_int8_t const* buffer,
 // Private Method
 
 // octet 파싱
-void RequestParser::parseOctet(u_int8_t const& octet) {
+void RequestParser::parseOctet(octet_t const& octet) {
   switch (_status % 10) {
     case READY:
       _status = REQUEST_LINE;
@@ -205,7 +205,7 @@ void RequestParser::parseOctet(u_int8_t const& octet) {
 
 // RequestLine 파싱
 // - CRLF가 입력되었을 경우 입력이 끝났다고 정의
-void RequestParser::parseRequestLine(u_int8_t const& octet) {
+void RequestParser::parseRequestLine(octet_t const& octet) {
   _requestLine.push_back(octet);
 
   if (octet == '\n' and isEndWithCRLF(_requestLine)) {
@@ -223,7 +223,7 @@ void RequestParser::parseRequestLine(u_int8_t const& octet) {
 // HeaderField 파싱
 // - CRLF가 입력되었을 경우 header field 한 줄의 입력이 끝났다고 정의
 // - 단, CRLF만 입력되었을 경우는 header field의 입력 종료로 처리
-void RequestParser::parseHeaderField(u_int8_t const& octet) {
+void RequestParser::parseHeaderField(octet_t const& octet) {
   _header.push_back(octet);
 
   if (octet == '\n' and isEndWithCRLF(_header)) {
@@ -242,7 +242,7 @@ void RequestParser::parseHeaderField(u_int8_t const& octet) {
 
 // body 파싱
 // - bodyLength 만큼 저장되었을 경우 status를 DONE으로 변경
-void RequestParser::parseBodyContentLength(u_int8_t const& octet) {
+void RequestParser::parseBodyContentLength(octet_t const& octet) {
   _body.push_back(octet);
 
   if (_body.size() == _bodyLength) {
@@ -253,7 +253,7 @@ void RequestParser::parseBodyContentLength(u_int8_t const& octet) {
 }
 
 // chunk body 파싱
-void RequestParser::parseBodyChunked(u_int8_t const& octet) {
+void RequestParser::parseBodyChunked(octet_t const& octet) {
   switch (_status) {
     case BODY_CHUNKED:
       _status = BODY_CHUNK_SIZE;
@@ -278,7 +278,7 @@ void RequestParser::parseBodyChunked(u_int8_t const& octet) {
 // - chunk-size가 0인 경우 last-chunk로 처리 후
 //   입력받은 body를 request 객체에 저장
 // - chunk-size가 1 이상인 경우 chunk-data를 읽도록 상태 변경
-void RequestParser::parseBodyChunkSize(u_int8_t const& octet) {
+void RequestParser::parseBodyChunkSize(octet_t const& octet) {
   _chunkSizeBuffer.push_back(octet);
 
   if (octet == '\n' and isEndWithCRLF(_chunkSizeBuffer)) {
@@ -295,7 +295,7 @@ void RequestParser::parseBodyChunkSize(u_int8_t const& octet) {
 
 // chunk body에 대한 chunk-data 파싱
 // - chunk-size 만큼 chunk-data를 읽은 후 CRLF가 입력되지 않았을 경우 예외 발생
-void RequestParser::parseBodyChunkData(u_int8_t const& octet) {
+void RequestParser::parseBodyChunkData(octet_t const& octet) {
   size_t const crlfLength = 2;
 
   size_t const bodySize = _body.size();
@@ -317,7 +317,7 @@ void RequestParser::parseBodyChunkData(u_int8_t const& octet) {
 // chunk body에 대한 Trailer 파싱
 // - Trailer는 무시
 // - 형식 검사를 하지 않고 CRLF만 들어올 경우 종료
-void RequestParser::parseBodyChunkTrailer(u_int8_t const& octet) {
+void RequestParser::parseBodyChunkTrailer(octet_t const& octet) {
   _header.push_back(octet);
 
   if (octet == '\n' and isEndWithCRLF(_header)) {
@@ -511,7 +511,7 @@ bool RequestParser::isInvalidFormatSize(std::vector<std::string> const& result,
 
 // 인자로 받은 vec이 CRLF로 끝나는지 여부 반환
 // - vec의 size가 2 미만인 경우 false로 처리
-bool RequestParser::isEndWithCRLF(std::vector<u_int8_t> const& vec) {
+bool RequestParser::isEndWithCRLF(std::vector<octet_t> const& vec) {
   if (vec.size() < 2) {
     return false;
   }
@@ -526,7 +526,7 @@ bool RequestParser::isEndWithCRLF(std::vector<u_int8_t> const& vec) {
 // vec에서 CRLF 제거
 // - 인자로 받은 vec이 CRLF로 끝난다고 가정
 // - vec의 size가 2 미만인 경우 2000 예외 발생
-void RequestParser::removeCRLF(std::vector<u_int8_t>& vec) {
+void RequestParser::removeCRLF(std::vector<octet_t>& vec) {
   if (vec.size() < 2) {
     throw std::runtime_error(
         "[2000] RequestParser: removeCRLF - CRLF does not exist for removal.");

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -341,7 +341,7 @@ void RequestParser::setupBodyParse(void) {
 // - 한 줄의 입력을 처리
 // - size가 2가 아닌 경우 예외 발생
 // - field-name의 길이가 1 미만이거나 Whitespace로 끝나는 경우 예외 발생
-// - Request 객체에 이미 존재하는 field-name일 경우 예외 발생
+// - host 또는 connection인 경우 fieldValue를 소문자로 저장
 std::vector<std::string> RequestParser::processHeaderField() {
   removeCRLF(_header);
 
@@ -363,14 +363,12 @@ std::vector<std::string> RequestParser::processHeaderField() {
         "allowed between the header field-name and colon");
   }
 
-  if (_request.isHeaderFieldNameExists(result[fieldNameIndex])) {
-    throw StatusException(
-        HTTP_BAD_REQUEST,
-        "[2202] RequestParser: processHeaderField - duplicate field-name");
-  }
-
-  toLowerCase(result[fieldNameIndex]);
   result[fieldValueIndex] = trim(result[fieldValueIndex]);
+  toLowerCase(result[fieldNameIndex]);
+  if (result[fieldNameIndex] == "host" or
+      result[fieldNameIndex] == "connection")
+    toLowerCase(result[fieldValueIndex]);
+
   return result;
 }
 

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -63,6 +63,7 @@ class RequestParser {
   bool isStorageBufferNotEmpty(void);
 
  private:
+  void setBodyLength(size_t bodyLength);
   void setBodyLength(std::string const& bodyLengthString);
   void setChunkSize(std::string const& chunkSizeString);
   void setStorageBuffer(size_t startIdx, u_int8_t const* buffer,

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "../utils/Config.hpp"
 #include "../utils/StatusException.hpp"
 #include "Request.hpp"
 
@@ -35,12 +36,12 @@ class RequestParser {
   Request _request;
 
   enum EParsingStatus _status;
-  std::vector<u_int8_t> _requestLine;
-  std::vector<u_int8_t> _header;
-  std::vector<u_int8_t> _body;
+  std::vector<octet_t> _requestLine;
+  std::vector<octet_t> _header;
+  std::vector<octet_t> _body;
 
-  std::vector<u_int8_t> _storageBuffer;
-  std::vector<u_int8_t> _chunkSizeBuffer;
+  std::vector<octet_t> _storageBuffer;
+  std::vector<octet_t> _chunkSizeBuffer;
 
   size_t _chunkSize;
   size_t _bodyLength;
@@ -57,7 +58,7 @@ class RequestParser {
 
   void initRequestLocationAndFullPath(Location const& location);
 
-  void parse(u_int8_t const* buffer, ssize_t bytesRead);
+  void parse(octet_t const* buffer, ssize_t bytesRead);
   void clear();
 
   bool isStorageBufferNotEmpty(void);
@@ -66,17 +67,17 @@ class RequestParser {
   void setBodyLength(size_t bodyLength);
   void setBodyLength(std::string const& bodyLengthString);
   void setChunkSize(std::string const& chunkSizeString);
-  void setStorageBuffer(size_t startIdx, u_int8_t const* buffer,
+  void setStorageBuffer(size_t startIdx, octet_t const* buffer,
                         ssize_t bytesRead);
 
-  void parseOctet(u_int8_t const& octet);
-  void parseRequestLine(u_int8_t const& octet);
-  void parseHeaderField(u_int8_t const& octet);
-  void parseBodyContentLength(u_int8_t const& octet);
-  void parseBodyChunked(u_int8_t const& octet);
-  void parseBodyChunkSize(u_int8_t const& octet);
-  void parseBodyChunkData(u_int8_t const& octet);
-  void parseBodyChunkTrailer(u_int8_t const& octet);
+  void parseOctet(octet_t const& octet);
+  void parseRequestLine(octet_t const& octet);
+  void parseHeaderField(octet_t const& octet);
+  void parseBodyContentLength(octet_t const& octet);
+  void parseBodyChunked(octet_t const& octet);
+  void parseBodyChunkSize(octet_t const& octet);
+  void parseBodyChunkData(octet_t const& octet);
+  void parseBodyChunkTrailer(octet_t const& octet);
 
   void setupBodyParse(void);
 
@@ -92,8 +93,8 @@ class RequestParser {
   bool isBodyChunk(void);
   EParsingStatus checkBodyParsingStatus(void);
   bool isInvalidFormatSize(std::vector<std::string> const& result, size_t size);
-  bool isEndWithCRLF(std::vector<u_int8_t> const& vec);
-  void removeCRLF(std::vector<u_int8_t>& vec);
+  bool isEndWithCRLF(std::vector<octet_t> const& vec);
+  void removeCRLF(std::vector<octet_t>& vec);
   void toLowerCase(std::string& str);
   std::string trim(std::string const& str);
   bool isWhitespace(int c);

--- a/http/StaticFileBuilder.cpp
+++ b/http/StaticFileBuilder.cpp
@@ -117,7 +117,7 @@ void StaticFileBuilder::openStaticFile(void) {
 
 // 파일 읽기
 void StaticFileBuilder::readStaticFile(void) {
-  u_int8_t buffer[BUFFER_SIZE];
+  octet_t buffer[BUFFER_SIZE];
   memset(buffer, 0, BUFFER_SIZE);
   ssize_t bytesRead = read(_fileFd, buffer, sizeof(buffer));
   _readIndex += bytesRead;

--- a/http/StaticFileBuilder.hpp
+++ b/http/StaticFileBuilder.hpp
@@ -18,7 +18,7 @@ class StaticFileBuilder : public AResponseBuilder {
   off_t _fileSize;
   off_t _readIndex;
 
-  std::vector<u_int8_t> _storageBuffer;
+  std::vector<octet_t> _storageBuffer;
 
  public:
   StaticFileBuilder(Request const& request);

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -57,7 +57,7 @@ void Connection::readSocket(void) {
     setStatus(ON_RECV);
   }
 
-  u_int8_t buffer[BUFFER_SIZE];
+  octet_t buffer[BUFFER_SIZE];
   memset(buffer, 0, BUFFER_SIZE);
   ssize_t bytesRead = read(_fd, buffer, sizeof(buffer));
 
@@ -83,7 +83,7 @@ void Connection::readStorage(void) {
     setStatus(ON_RECV);
   }
 
-  u_int8_t tmp[1];
+  octet_t tmp[1];
 
   parseRequest(tmp, 0);
   updateLastCallTime();
@@ -91,7 +91,7 @@ void Connection::readStorage(void) {
 
 // RequestParser에서 요청 읽기
 // - bytesRead를 0으로 하면 storage에 남아있는 내용을 파싱
-void Connection::parseRequest(u_int8_t const* buffer, ssize_t bytesRead) {
+void Connection::parseRequest(octet_t const* buffer, ssize_t bytesRead) {
   _requestParser.parse(buffer, bytesRead);
 
   // 헤더 읽기 완료

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -317,7 +317,7 @@ bool Connection::isSameState(EStatus status) { return (_status == status); }
 // path와 host 정보를 가지고 알맞은 location 블럭을 할당
 void Connection::setRequestParserLocation(Request const& request) {
   std::string const& path = request.getPath();
-  std::string const& host = request.getHeaderFieldValues("host");
+  std::string const host = request.getHost();
 
   Location const& location = _manager.getLocation(path, host);
   _requestParser.initRequestLocationAndFullPath(location);

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -175,7 +175,8 @@ void Connection::selectResponseBuilder(void) {
   }
 
   // uri에 location에 포함된 cgi 확장자가 붙어있는 경우 cgi build
-  if (Config::findFileExtension(fullPath) == location.getCgiExtention()) {
+  if (location.hasCgiInfo() and
+      Config::findFileExtension(fullPath) == location.getCgiExtention()) {
     // cgi builder
     return;
   }

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -15,6 +15,7 @@
 #include "../http/Request.hpp"
 #include "../http/RequestParser.hpp"
 #include "../http/StaticFileBuilder.hpp"
+#include "../utils/Config.hpp"
 #include "../utils/Util.hpp"
 #include "ServerManager.hpp"
 
@@ -65,7 +66,7 @@ class Connection {
   static int const BUFFER_SIZE = 1024;
   ServerManager& _manager;
 
-  void parseRequest(u_int8_t const* buffer, ssize_t bytesRead);
+  void parseRequest(octet_t const* buffer, ssize_t bytesRead);
   void setRequestParserLocation(Request const& request);
   void removeAllBuilderFd(void);
 

--- a/utils/Config.cpp
+++ b/utils/Config.cpp
@@ -35,6 +35,7 @@ std::map<int, std::string> Config::initializeStatusMessages(void) {
   messages[502] = "Bad Gateway";
   messages[503] = "Service Unavailable";
   messages[504] = "Gateway Timeout";
+  messages[505] = "HTTP Version Not Supported";
   return messages;
 }
 

--- a/utils/Config.hpp
+++ b/utils/Config.hpp
@@ -7,6 +7,8 @@
 
 #include "Util.hpp"
 
+typedef unsigned char octet_t;
+
 // 서버가 사용하는 설정들을 정의해 둔 static 클래스
 class Config {
  public:


### PR DESCRIPTION
## 구현 사항

### 1. method
- 지원하지 않는 메서드인 경우 [501 Not Implemented](https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.2) 반환
  - 구현되지 않은 것 + 인식되지 않은 것(이상한 값)
  - 대소문자를 구분하기 때문에 대문자만 검사
        
### 2. request-target
- request-target 길이가 너무 길다면 [414 URI Too Long](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.12)
  `Config::MAX_URI_SIZE < requestTarget.size()`
- **400 Bad Request** 검사
  - [origin-form](https://datatracker.ietf.org/doc/html/rfc7230#section-5.3.1)을 만족해야 하기 때문에 `/`로 시작하는지 확인
  - 아래의 segment 조건을 만족하는지 확인
    - pct-encoded 라면 % 뒤 16진수가 2개 있는지 확인 
    ```jsx
    absolute-path = 1*( "/" segment )
    segment       = *pchar
    pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
    unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
    pct-encoded   = "%" HEXDIG HEXDIG
    sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
                     / "*" / "+" / "," / ";" / "="
    ```
- 저장할 때 [pct-encoded](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1) 를 decode 해서 저장

### 3. HTTP-version
> https://datatracker.ietf.org/doc/html/rfc7230#section-2.6
- 아래의 형식을 만족하지 않는 경우 **400 Bad Request**
```
HTTP-version  = HTTP-name "/" DIGIT "." DIGIT
HTTP-name     = %x48.54.54.50 ; "HTTP", case-sensitive
``` 
- HTTP/1.0, HTTP/1.1이 아닌 경우 [505 HTTP Version Not Supported](https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.6) 
    
### 4. Header
> Host: https://datatracker.ietf.org/doc/html/rfc7230#section-5.4
- 중복된 헤더 입력 시 **400 Bad Request**
- Host, Conncetion 헤더 저장
    - 필드값의 대소문자를 구분하지 않기 때문에 소문자로 변환 후 저장 
- getHost 함수 구현
  `Host = uri-host [ ":" port ]`
    - 처음 나오는 `:`를 기준으로 앞의 값을 호스트로 반환
    - Host 헤더가 없는 경우 HTTP/1.1 →  `400 Bad Request` / HTTP/1.0 → “”
    - Host 헤더가 존재한다면 해당하는 값 반환
- isConnectionClose 함수 구현
  - isConnectionClose 멤버 변수를 제거하고 함수에서 모두 구현하도록 변경
  - HTTP/1.0은 Connection 헤더 값과 상관없이 무조건 close
  - HTTP/1.1은 Connection 헤더 값이 정확히 close가 들어가있으면 close
        
### 5. body
- client-max-body-size 검사
  - RequestParser에서 setBodySize(void) 함수 호출 시 내부에서 검사
  - max body size보다 크다면 [413 Payload Too Large](https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.11) 예외 발생
  - 413 상태 코드에 대해 클라이언트가 요청을 계속하지 못하도록 커넥션 닫기
- GET, DELETE 일 때 body를 읽으려고 하면 **400 Bad Request**

### 자잘한 수정 사항
> 405: https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.5
- autoindex일 때 get, post가 아닌 경우 상태 코드 변경
  - **405 Method Not Allowed** 에서 **403 forbidden**으로 변경
  - 405일 경우 Allow 헤더 필드를 추가하기 때문에 변경
- 405 응답 반환 시 Allow 헤더 추가
  - location에서 허용하는 method를 헤더에 추가해서 반환
- Transfer-Encoding 필더가 있을 때 Content-Length 필더가 존재하는 경우 처리
- u_int8_t → octet_t 로 변경
- content length 및 chunk size 입력 시 잘못된 예외 수정

## To-do!
- config 파싱할 때 server_name을 소문자로 저장하기