### PR TITLE
[Feat] builder select 로직 수정 및 BuilderSelector 클래스 구현 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ SRCS		= config/Server.cpp \
 			  http/AutoindexBuilder.cpp \
 			  http/RedirectBuilder.cpp \
 			  http/CgiBuilder.cpp \
+			  http/BuilderSelector.cpp \
 			  main.cpp
 				
 

--- a/config/Server.hpp
+++ b/config/Server.hpp
@@ -1,6 +1,7 @@
 #ifndef __SERVER_HPP__
 #define __SERVER_HPP__
 
+#include <cstring>
 #include <map>
 #include <set>
 #include <string>

--- a/http/AutoindexBuilder.hpp
+++ b/http/AutoindexBuilder.hpp
@@ -7,6 +7,7 @@
 
 #include <ctime>
 #include <sstream>
+#include <stdexcept>
 
 #include "../utils/StatusException.hpp"
 #include "../utils/Util.hpp"

--- a/http/BuilderSelector.cpp
+++ b/http/BuilderSelector.cpp
@@ -1,0 +1,69 @@
+#include "BuilderSelector.hpp"
+
+// 요청에 알맞는 response builder 선택
+// - AResponseBuilder를 상속받은 객체를 동적할당한 포인터 반환
+AResponseBuilder* BuilderSelector::getMatchingBuilder(Request const& request) {
+  Location const& location = request.getLocation();
+  std::string fullPath = request.getFullPath();
+
+  if (location.isRedirectBlock())
+    return new RedirectBuilder(request, location.getRedirectUri());
+
+  if (BuilderSelector::isAutoindexBuilderSelected(request))
+    return new AutoindexBuilder(request);
+
+  if (fullPath.back() == '/') fullPath = request.generateIndexPath();
+
+  if (BuilderSelector::isCgiBuilderSelected(request, fullPath))
+    return new CgiBuilder(request);
+
+  if (BuilderSelector::isDirRedirectSelected(fullPath))
+    return new RedirectBuilder(request, request.getPath() + '/');
+
+  return new StaticFileBuilder(request);
+}
+
+// 디렉토리 경로(/로 끝나는 path)인 경우
+// - GET일 때 index 파일이 존재하지 않을 때
+// - POST, DELETE의 경우
+bool BuilderSelector::isAutoindexBuilderSelected(Request const& request) {
+  std::string fullPath = request.getFullPath();
+
+  if (fullPath.back() != '/') return false;
+
+  if (request.getMethod() != HTTP_GET) return true;
+
+  fullPath = request.generateIndexPath();
+  if (access(fullPath.c_str(), F_OK) == -1) return true;
+
+  return false;
+}
+
+// cgi 확장자 파일 또는 POST, DELETE의 경우
+bool BuilderSelector::isCgiBuilderSelected(Request const& request,
+                                           std::string const& fullPath) {
+  Location const& location = request.getLocation();
+
+  if (request.getMethod() != HTTP_GET) return true;
+
+  if (location.hasCgiInfo() and
+      Config::findFileExtension(fullPath) == location.getCgiExtention())
+    return true;
+
+  return false;
+}
+
+// 해당 파일이 디렉토리 경로이지만 /가 붙어있지 않은 경우
+bool BuilderSelector::isDirRedirectSelected(std::string const& fullPath) {
+  if (access(fullPath.c_str(), F_OK) == -1) return false;
+
+  // 파일 정보 확인
+  struct stat statbuf;
+  if (stat(fullPath.c_str(), &statbuf) == -1) {
+    throw std::runtime_error(
+        "[4004] BuilderSelector: isDirRedirectSelected - stat failed: " +
+        fullPath);
+  }
+
+  return S_ISDIR(statbuf.st_mode);
+}

--- a/http/BuilderSelector.hpp
+++ b/http/BuilderSelector.hpp
@@ -1,0 +1,33 @@
+#ifndef __BUILDER_SELECTOR_HPP__
+#define __BUILDER_SELECTOR_HPP__
+
+#include <sys/stat.h>
+
+#include <stdexcept>
+
+#include "../http/AResponseBuilder.hpp"
+#include "../http/AutoindexBuilder.hpp"
+#include "../http/CgiBuilder.hpp"
+#include "../http/ErrorBuilder.hpp"
+#include "../http/RedirectBuilder.hpp"
+#include "../http/Request.hpp"
+#include "../http/StaticFileBuilder.hpp"
+
+// 적절한 ResponseBuilder를 선택
+class BuilderSelector {
+ public:
+  static AResponseBuilder* getMatchingBuilder(Request const& request);
+
+ private:
+  BuilderSelector(void);
+  BuilderSelector(BuilderSelector const& BuilderSelector);
+  ~BuilderSelector(void);
+  BuilderSelector& operator=(BuilderSelector const& BuilderSelector);
+
+  static bool isAutoindexBuilderSelected(Request const& request);
+  static bool isCgiBuilderSelected(Request const& request,
+                                   std::string const& fullPath);
+  static bool isDirRedirectSelected(std::string const& fullPath);
+};
+
+#endif

--- a/http/CgiBuilder.cpp
+++ b/http/CgiBuilder.cpp
@@ -148,7 +148,7 @@ void CgiBuilder::childProcess(int* const p_to_c, int* const c_to_p) {
   std::string const& cgiPath = getRequest().getLocation().getCgiPath();
 
   if (access(cgiPath.c_str(), F_OK) < 0 or access(cgiPath.c_str(), X_OK) < 0) {
-    std::cout << "Status: 500 Internal Server Error\r\n";
+    std::cout << "Status: 500 Access Fail\r\n";
     std::cout << "Content-Type: text/html\r\n\r\n";
     std::cout << Config::defaultErrorPageBody(500);
     exit(1);
@@ -157,7 +157,7 @@ void CgiBuilder::childProcess(int* const p_to_c, int* const c_to_p) {
   // cgi에 인자 및 환경변수 전송
   if (execve(cgiPath.c_str(), NULL, envp) < 0) {
     freeEnvArray(envp);
-    std::cout << "Status: 500 Internal Server Error\r\n";
+    std::cout << "Status: 500 Execve Fail\r\n";
     std::cout << "Content-Type: text/html\r\n\r\n";
     std::cout << Config::defaultErrorPageBody(500);
     exit(1);
@@ -277,6 +277,8 @@ void CgiBuilder::buildResponseContent(std::string const& cgiResponse) {
 
         iss >> statusCode;  // 상태 코드를 정수로 읽어들임
         std::getline(iss, statusText);  // 상태 텍스트 읽기 (예: "OK")
+
+        std::cout << "cgi status text: " << statusText << std::endl;  // debug
 
         if (statusCode > 0) {
           _response.setStatusCode(statusCode);

--- a/http/CgiBuilder.hpp
+++ b/http/CgiBuilder.hpp
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include <cctype>
+#include <cstring>
 #include <iostream>
 #include <map>
 #include <stdexcept>

--- a/http/ErrorBuilder.hpp
+++ b/http/ErrorBuilder.hpp
@@ -5,6 +5,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <stdexcept>
 #include <string>
 
 #include "../core/Kqueue.hpp"

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -304,7 +304,8 @@ bool Request::isValidRequestTarget(std::string const& requestTarget) {
   for (size_t i = 0; i < size; i++) {
     char ch = requestTarget[i];
 
-    if (isalpha(ch) or isdigit(ch) or others.find(ch) != std::string::npos)
+    if (std::isalpha(ch) or std::isdigit(ch) or
+        others.find(ch) != std::string::npos)
       continue;
 
     if (ch == '%' and i + 2 < size) {

--- a/http/Request.hpp
+++ b/http/Request.hpp
@@ -2,7 +2,9 @@
 #define __REQUEST_HPP__
 
 #include <cctype>
+#include <cstring>
 #include <map>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/http/RequestParser.hpp
+++ b/http/RequestParser.hpp
@@ -3,8 +3,10 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 #include <map>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/http/Response.hpp
+++ b/http/Response.hpp
@@ -1,9 +1,10 @@
 #ifndef __RESPONSE_HPP__
 #define __RESPONSE_HPP__
 
-#include <exception>
+#include <cstring>
 #include <map>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 #include "../utils/Config.hpp"
@@ -50,6 +51,7 @@ class Response {
   void clear(void);
 
   bool isHeaderFieldNameExists(std::string const& fieldName) const;
+
  private:
 };
 

--- a/http/StaticFileBuilder.hpp
+++ b/http/StaticFileBuilder.hpp
@@ -5,6 +5,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <stdexcept>
+
 #include "../core/Kqueue.hpp"
 #include "../core/Socket.hpp"
 #include "../utils/Config.hpp"

--- a/main.cpp
+++ b/main.cpp
@@ -44,7 +44,7 @@ std::vector<Server> exampleParseConfig(void) {
   location1_2.addAllowMethod(HTTP_POST);
   location1_2.setAutoIndex(false);
   location1_2.setCgiExtention(".bla");
-  location1_2.setCgiPath("/Users/wonyang/Project/webserv/www/cgi_tester");
+  location1_2.setCgiPath("/Users/wonyang/Project/webserv/tester/cgi_tester");
   location1_2.setUploadDir("/Users/wonyang/Project/webserv/www/");
 
   Location location1_3("/post_body",

--- a/server/Connection.hpp
+++ b/server/Connection.hpp
@@ -1,15 +1,16 @@
 #ifndef __CONNECTION_HPP__
 #define __CONNECTION_HPP__
 
-#include <sys/stat.h>
 #include <unistd.h>
 
 #include <ctime>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 #include "../http/AResponseBuilder.hpp"
 #include "../http/AutoindexBuilder.hpp"
+#include "../http/BuilderSelector.hpp"
 #include "../http/CgiBuilder.hpp"
 #include "../http/ErrorBuilder.hpp"
 #include "../http/RedirectBuilder.hpp"

--- a/server/EventLoop.hpp
+++ b/server/EventLoop.hpp
@@ -2,6 +2,7 @@
 #define __EVENTLOOP_HPP__
 
 #include <map>
+#include <stdexcept>
 #include <vector>
 
 #include "../core/Kqueue.hpp"

--- a/server/ServerManager.cpp
+++ b/server/ServerManager.cpp
@@ -2,8 +2,8 @@
 
 #include <unistd.h>
 
-#include <exception>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/utils/Config.hpp
+++ b/utils/Config.hpp
@@ -1,9 +1,11 @@
 #ifndef __CONFIG_HPP__
 #define __CONFIG_HPP__
 
+#include <cstring>
 #include <map>
 #include <sstream>
 #include <string>
+#include <stdexcept>
 
 #include "Util.hpp"
 

--- a/utils/Util.hpp
+++ b/utils/Util.hpp
@@ -2,6 +2,7 @@
 #define __UTIL_HPP__
 
 #include <sstream>
+#include <stdexcept>
 #include <string>
 
 class Util {


### PR DESCRIPTION
## 구현 사항

### builder select 로직 수정 
**[ 수정 사항 ]**
- cgi 확장자라면 파일 유무와 상관 없이 CGI Builder로 이동
- POST, DELETE도 파일 유무와 상관 없이 CGI Builder로 이동
- 디렉토리인 경우(/로 끝나는 path) GET일때만 index 파일 존재 유무 확인

**[ 최종 구현 로직 ]**
```
1. 허용되지 않는 메서드인 경우 501 예외 발생
2. redirect가 location 블록에 존재할 경우 해당 경로로 `redirect`
3. 디렉토리 경로인 경우
    - GET 요청의 경우 index 파일을 붙이고 파일이 존재하지 않는 경우
    - 다른 모든 경우 `autoindex build`
4. 디렉토리 경로인 경우 index 파일 경로를 fullPath로 변경
    - 다른 경우는 모두 autoindex builder가 이미 선택됨
5. 디렉토리 경로가 아닌 POST, DELETE 요청이거나, uri에 cgi 확장자가 붙어있는 경우 `cgi build`
6.  uri에 해당하는 파일이 디렉토리로 존재한다면 경로 뒤 `/` 를 붙이고 `redirect`
7. 모두 아닌 경우 `static build`
    - uri에 해당하는 파일이 없으면 404는 static builder에서 실행하도록 선택시에는 검사 제외
```

### BuilderSelector 클래스 구현
- response builder 선택하는 부분을 connection 객체에서 BuilderSelector 클래스로 이동

### 자잘한 수정

- size_t 헤더인 cstring 추가
- std::runtime_error 헤더인 stdexcept 추가
- isalpha, isdigit에 std:: 추가
- cgi 결과 메시지 debug용 출력 추가
- tester 경로 수정

## To-do!
- memset 함수 수정
- post, delete일 때 cgi path를 location에서 받아오는 것이 아닌 직접 구현한 python cgi 경로를 추가
- cgi에서 get일 때 index file 붙이기
- 자식 프로세스에서 예외가 터졌을 때 500 보내도록 구현