### PR TITLE
[Feat] 상대경로를 제거하여 반환하는 함수 구현

### DIFF
--- a/utils/Util.cpp
+++ b/utils/Util.cpp
@@ -17,3 +17,36 @@ int Util::stoi(std::string const& str) {
   }
   return n;
 }
+
+// path에서 .과 ..을 계산하여 반환
+// - ..로 인해 /보다 뒤로 갈 경우 /로 고정
+std::string const Util::removeDotSegments(std::string const& path) {
+  std::string inputBuffer = path;
+  std::string outputBuffer;
+
+  while (!inputBuffer.empty()) {
+    std::size_t segmentEnd = inputBuffer.find('/', 1);
+    std::string segment = segmentEnd != std::string::npos
+                              ? inputBuffer.substr(0, segmentEnd)
+                              : inputBuffer;
+
+    if (segment == "/." || segment == ".") {
+      // pass
+    } else if (segment == "/.." || segment == "..") {
+      std::size_t pos = outputBuffer.find_last_of('/');
+      if (pos != std::string::npos) {
+        outputBuffer.erase(pos);
+      }
+    } else if (!segment.empty() && segment != "/") {
+      outputBuffer += segment;
+    }
+
+    if (segmentEnd != std::string::npos) {
+      inputBuffer.erase(0, segmentEnd);
+    } else {
+      inputBuffer.clear();
+    }
+  }
+
+  return outputBuffer.empty() ? "/" : outputBuffer;
+}

--- a/utils/Util.hpp
+++ b/utils/Util.hpp
@@ -9,6 +9,7 @@ class Util {
  public:
   static std::string const itos(int n);
   static int stoi(std::string const& str);
+  static std::string const removeDotSegments(std::string const& path);
 
  private:
   Util(void);


### PR DESCRIPTION
- / 기준으로 구분된 문자열을 세그먼트라고 부름

1. 입력 버퍼는 이제 추가된 경로 구성 요소로 초기화되고 출력 버퍼는 빈 문자열로 초기화됩니다.
2. 입력 버퍼가 비어 있지 않은 동안 다음과 같이 반복합니다:
    
    A.  입력 버퍼가 접두사 "../" 또는 "./"로 시작하면 입력 버퍼에서 해당 접두사를 제거하고, 그렇지 않으면 다른 조치를 취하세요.
    
    B. 입력 버퍼가 접두사 "/./" 또는 "/."로 시작하는 경우(여기서 "."는 완전한 경로 세그먼트), 입력 버퍼에서 해당 접두사를 "/"로 바꾸고, 그렇지 않으면 다른 조치를 취하세요.
    
    C. 입력 버퍼가 "/../" 또는 "/.."의 접두사로 시작하는 경우, 여기서 ".."는 완전한 경로 세그먼트인 경우, 입력 버퍼에서 해당 접두사를 "/"로 바꾸고 출력 버퍼에서 마지막 세그먼트와 그 앞의 "/"(있는 경우)를 제거합니다,
    
    D. 입력 버퍼가 "." 또는 ".."로만 구성된 경우 입력 버퍼에서 해당 부분을 제거하고, 그렇지 않은 경우 다른 조치를 취하세요.
    
    E. 입력 버퍼의 첫 번째 경로 세그먼트를 초기 "/"를 포함하여 출력 버퍼의 끝으로 이동합니다.

3. 마지막으로, 출력 버퍼는 remove_dot_segments의 결과로 반환됩니다.