### PR TITLE
[Feat] config 값 유효성 검사

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -1,4 +1,4 @@
-project_root /Users/jeongmin/webserv2
+project_root /Users/wonyang/Project/webserv
 
 server {
 	listen 127.0.0.1 8080;

--- a/conf/default.conf
+++ b/conf/default.conf
@@ -6,23 +6,23 @@ server {
 
 	location / {
 		root /www;
-		index upload.html;
+		index /upload.html;
 		allow_method GET;
 		client_max_body_size 10000000;
 		autoindex off;
-		error_page 404 /404.html;
+		error_page 404 /www/404.html;
 	}
 
 	location /upload/ {
 		root /www/upload;
-		index bird.png;
+		index /bird.png;
 		allow_method GET DELETE;
 		autoindex on;
 	}
 
 	location /cgi-bin/ {
 		root /cgi-bin;
-		index image-view.py;
+		index /image-view.py;
 		allow_method GET POST;
 		autoindex off;
 		cgi .py /cgi-bin/my-python-cgi.py /www/upload;
@@ -35,16 +35,16 @@ server {
 
 	location / {
 		root /www;
-		index index.html;
+		index /index.html;
 		allow_method GET;
 		client_max_body_size 15000000;
 		autoindex off;
-		error_page 404 /404.html;
+		error_page 404 /www/404.html;
 	}
 
 	location /cgi-bin/ {
 		root /cgi-bin;
-		index hello.rb;
+		index /hello.rb;
 		allow_method GET;
 		autoindex off;
 		cgi .rb /cgi-bin/my-ruby-cgi.rb /www/upload;

--- a/conf/tester.conf
+++ b/conf/tester.conf
@@ -5,22 +5,22 @@ server {
 
 	location / {
 		root /www;
-		index index.html;
+		index /index.html;
 		allow_method GET;
 		autoindex on;
 	}
 
 	location /directory {
 		root /www/YoupiBanane;
-		index youpi.bad_extension;
+		index /youpi.bad_extension;
 		allow_method GET POST;
 		autoindex off;
-		cgi .bla /tester/cgi_tester /upload_file;
+		cgi .bla /tester/cgi_tester /www/YoupiBanane/upload_file;
 	}
 
 	location /post_body {
 		root /www/YoupiBanane;
-		index youpi.bad_extension;
+		index /youpi.bad_extension;
 		client_max_body_size 100;
 	}
 }

--- a/config/ConfigParser.cpp
+++ b/config/ConfigParser.cpp
@@ -122,7 +122,7 @@ Location const ConfigParser::parseLocation(void) {
     }
   }
 
-  location.printConfiguration();  // debug
+  // location.printConfiguration();  // debug
 
   if (location.isRequiredValuesSet() == false) {
     throw std::runtime_error(

--- a/config/ConfigParser.cpp
+++ b/config/ConfigParser.cpp
@@ -187,7 +187,7 @@ void ConfigParser::storeLocationCgi(Location& location) {
   split(_line, result);
   checkSize(result, 4);
 
-  location.setCgiExtention(result[1]);
+  location.setCgiExtension(result[1]);
   location.setCgiPath(result[2]);
   location.setUploadDir(result[3]);
 }

--- a/config/ConfigParser.cpp
+++ b/config/ConfigParser.cpp
@@ -308,11 +308,13 @@ void ConfigParser::checkSize(std::vector<std::string> const& result,
 }
 
 void ConfigParser::removeSemicolon(void) {
-  if (_line.back() != ';') {
+  size_t size = _line.size();
+
+  if (_line[size - 1] != ';') {
     throwFormatError("ConfigParser: removeSemicolon");
   }
 
-  _line.pop_back();
+  _line.substr(0, size - 1);
 }
 
 void ConfigParser::throwFormatError(std::string const& func) {

--- a/config/ConfigParser.cpp
+++ b/config/ConfigParser.cpp
@@ -314,7 +314,7 @@ void ConfigParser::removeSemicolon(void) {
     throwFormatError("ConfigParser: removeSemicolon");
   }
 
-  _line.substr(0, size - 1);
+  _line = _line.substr(0, size - 1);
 }
 
 void ConfigParser::throwFormatError(std::string const& func) {

--- a/config/ConfigParser.cpp
+++ b/config/ConfigParser.cpp
@@ -213,7 +213,7 @@ void ConfigParser::storeServerListenInfo(Server& server) {
   checkSize(result, 3);
 
   server.setHostIp(result[1]);
-  server.setPort(Util::stoi(result[2]));
+  server.setPort(result[2]);
 }
 
 void ConfigParser::storeServerName(Server& server) {

--- a/config/ConfigParser.cpp
+++ b/config/ConfigParser.cpp
@@ -149,7 +149,7 @@ void ConfigParser::storeLocationMethod(Location& location) {
   }
 
   for (size_t i = 1; i < result.size(); i++) {
-    location.addAllowMethod(matchEHttpMethod(result[i]));
+    location.addAllowMethod(result[i]);
   }
 }
 
@@ -166,14 +166,7 @@ void ConfigParser::storeLocationAutoindex(Location& location) {
   split(_line, result);
   checkSize(result, 2);
 
-  if (result[1] == "on")
-    location.setAutoIndex(true);
-  else if (result[1] == "off")
-    location.setAutoIndex(false);
-  else {
-    throw std::runtime_error(
-        "[1204] ConfigParser: storeLocationAutoindex - invalid option");
-  }
+  location.setAutoIndex(result[1]);
 }
 
 void ConfigParser::storeLocationErrorPage(Location& location) {
@@ -304,16 +297,6 @@ void ConfigParser::checkSize(std::vector<std::string> const& result,
   if (result.size() != size) {
     throwFormatError("ConfigParser: checkSize");
   }
-}
-
-EHttpMethod ConfigParser::matchEHttpMethod(std::string method) {
-  Util::toLowerCase(method);
-
-  if (method == "get") return HTTP_GET;
-  if (method == "post") return HTTP_POST;
-  if (method == "delete") return HTTP_DELETE;
-  throw std::runtime_error(
-      "[1210] ConfigParser: matchEHttpMethod - match failed");
 }
 
 void ConfigParser::removeSemicolon(void) {

--- a/config/ConfigParser.cpp
+++ b/config/ConfigParser.cpp
@@ -26,7 +26,9 @@ void ConfigParser::storeProjectRoot(void) {
   std::vector<std::string> result;
   split(_line, result);
   checkSize(result, 2);
-  // path 유효성 검사
+  if (Util::isValidPath(result[1]) == false)
+    throw std::runtime_error(
+        "[1210] ConfigParser: storeProjectRoot - invalid path");
   _projectRootPath = result[1];
 }
 

--- a/config/ConfigParser.hpp
+++ b/config/ConfigParser.hpp
@@ -64,7 +64,6 @@ class ConfigParser {
 
   void split(std::string const& line, std::vector<std::string>& result);
   void checkSize(std::vector<std::string> const& result, size_t size);
-  EHttpMethod matchEHttpMethod(std::string method);
   void removeSemicolon(void);
 
   void throwFormatError(std::string const& func);

--- a/config/Location.cpp
+++ b/config/Location.cpp
@@ -103,14 +103,14 @@ void Location::setRootPath(std::string const& rootPath) {
     throw std::runtime_error("[] Location: setRootPath - invalid path");
   }
 
-  _rootPath = convertPath(rootPath);
+  _rootPath = Util::convertPath(rootPath);
 }
 void Location::setIndexFile(std::string const& indexFile) {
   if (Util::isValidPath(indexFile) == false) {
     throw std::runtime_error("[] Location: indexFile - invalid path");
   }
 
-  _indexFile = convertPath(indexFile);
+  _indexFile = Util::convertPath(indexFile);
 }
 
 // - Location 블럭의 max body size 설정
@@ -140,7 +140,7 @@ void Location::addErrorPage(int statusCode, std::string const& path) {
         "[1101] Location: addErrorPage - duplicate status code");
   }
 
-  std::string const convertedPath = convertPath(path);
+  std::string const convertedPath = Util::convertPath(path);
   _errorPages[statusCode] = getFullPath(convertedPath);
 }
 
@@ -180,7 +180,7 @@ void Location::setRedirectUri(std::string const& path) {
   }
 
   _hasRedirectField = true;
-  _redirectUri = convertPath(path);
+  _redirectUri = Util::convertPath(path);
 }
 
 // CGI extension 설정
@@ -201,7 +201,7 @@ void Location::setCgiPath(std::string const& cgiPath) {
     throw std::runtime_error("[] Location: setCgiPath - invalid path");
   }
 
-  std::string const convertedPath = convertPath(cgiPath);
+  std::string const convertedPath = Util::convertPath(cgiPath);
   _cgiPath = getFullPath(convertedPath);
   _cgiFlag = true;
 }
@@ -213,7 +213,7 @@ void Location::setUploadDir(std::string const& dirPath) {
     throw std::runtime_error("[] Location: setUploadDir - invalid path");
   }
 
-  std::string const convertedPath = convertPath(dirPath);
+  std::string const convertedPath = Util::convertPath(dirPath);
   _uploadPath = getFullPath(convertedPath);
   _cgiFlag = true;
 }
@@ -321,8 +321,4 @@ std::string Location::getFullPath(std::string const& path) {
   }
 
   return projectRootPath + path;
-}
-
-std::string Location::convertPath(std::string const& path) {
-  return Util::removeDotSegments(Util::pctDecode(path));
 }

--- a/config/Location.cpp
+++ b/config/Location.cpp
@@ -187,7 +187,7 @@ void Location::setRedirectUri(std::string const& path) {
 // CGI extension 설정
 // - 한 번이라도 메서드가 호출된 경우 cgi를 가지고 있다고 판단
 void Location::setCgiExtension(std::string const& extension) {
-  if (extension.size() == 0 or extension.front() != '.') {
+  if (extension.size() == 0 or extension[0] != '.') {
     throw std::runtime_error(
         "[1114] Location: setCgiExtension - invalid extension");
   }
@@ -315,10 +315,12 @@ bool Location::isRequiredValuesSet(void) const {
 
 std::string Location::getFullPath(std::string const& path) {
   std::string projectRootPath = _projectRootPath;
-  if (path.front() != '/' and projectRootPath.back() != '/')
+  size_t projectPathSize = projectRootPath.size();
+
+  if (path[0] != '/' and projectRootPath[projectPathSize - 1] != '/')
     projectRootPath.push_back('/');
-  else if (path.front() == '/' and projectRootPath.back() == '/') {
-    projectRootPath.pop_back();
+  else if (path[0] == '/' and projectRootPath[projectPathSize - 1] == '/') {
+    projectRootPath = projectRootPath.substr(0, projectPathSize - 1);
   }
 
   return projectRootPath + path;

--- a/config/Location.cpp
+++ b/config/Location.cpp
@@ -100,14 +100,14 @@ void Location::setUri(std::string const& uri) { _uri = uri; }
 
 void Location::setRootPath(std::string const& rootPath) {
   if (Util::isValidPath(rootPath) == false) {
-    throw std::runtime_error("[] Location: setRootPath - invalid path");
+    throw std::runtime_error("[1108] Location: setRootPath - invalid path");
   }
 
   _rootPath = Util::convertPath(rootPath);
 }
 void Location::setIndexFile(std::string const& indexFile) {
   if (Util::isValidPath(indexFile) == false) {
-    throw std::runtime_error("[] Location: indexFile - invalid path");
+    throw std::runtime_error("[1109] Location: setIndexFile - invalid path");
   }
 
   _indexFile = Util::convertPath(indexFile);
@@ -128,11 +128,12 @@ void Location::setMaxBodySize(int size) {
 // - 이미 있는 상태코드를 다시 추가할 경우 예외 발생
 void Location::addErrorPage(int statusCode, std::string const& path) {
   if (statusCode < 0 or (statusCode / 100 != 4 and statusCode / 100 != 5)) {
-    throw std::runtime_error("[] Location: addErrorPage - invalid statusCode");
+    throw std::runtime_error(
+        "[1110] Location: addErrorPage - invalid statusCode");
   }
 
   if (Util::isValidPath(path) == false) {
-    throw std::runtime_error("[] Location: addErrorPage - invalid path");
+    throw std::runtime_error("[1111] Location: addErrorPage - invalid path");
   }
 
   if (_errorPages.find(statusCode) != _errorPages.end()) {
@@ -164,7 +165,7 @@ void Location::addAllowMethod(std::string methodString) {
 // - 호출하지 않을 시 기본값(false) 적용
 void Location::setAutoIndex(std::string const& setting) {
   if (setting != "on" and setting != "off") {
-    throw std::runtime_error("[] Location: setAutoIndex - invalid setting");
+    throw std::runtime_error("[1112] Location: setAutoIndex - invalid setting");
   }
 
   _autoIndex = setting == "on" ? true : false;
@@ -176,7 +177,7 @@ void Location::setAutoIndex(std::string const& setting) {
 // - 한번이라도 이 메서드가 호출된 경우 redirect 블럭으로 판단
 void Location::setRedirectUri(std::string const& path) {
   if (Util::isValidPath(path) == false) {
-    throw std::runtime_error("[] Location: setRedirectUri - invalid path");
+    throw std::runtime_error("[1113] Location: setRedirectUri - invalid path");
   }
 
   _hasRedirectField = true;
@@ -188,7 +189,7 @@ void Location::setRedirectUri(std::string const& path) {
 void Location::setCgiExtension(std::string const& extension) {
   if (extension.size() == 0 or extension.front() != '.') {
     throw std::runtime_error(
-        "[] Location: setCgiExtension - invalid extension");
+        "[1114] Location: setCgiExtension - invalid extension");
   }
   _cgiExtension = extension;
   _cgiFlag = true;
@@ -198,7 +199,7 @@ void Location::setCgiExtension(std::string const& extension) {
 // - 한 번이라도 메서드가 호출된 경우 cgi를 가지고 있다고 판단
 void Location::setCgiPath(std::string const& cgiPath) {
   if (Util::isValidPath(cgiPath) == false) {
-    throw std::runtime_error("[] Location: setCgiPath - invalid path");
+    throw std::runtime_error("[1115] Location: setCgiPath - invalid path");
   }
 
   std::string const convertedPath = Util::convertPath(cgiPath);
@@ -210,7 +211,7 @@ void Location::setCgiPath(std::string const& cgiPath) {
 // - 한 번이라도 메서드가 호출된 경우 cgi를 가지고 있다고 판단
 void Location::setUploadDir(std::string const& dirPath) {
   if (Util::isValidPath(dirPath) == false) {
-    throw std::runtime_error("[] Location: setUploadDir - invalid path");
+    throw std::runtime_error("[1116] Location: setUploadDir - invalid path");
   }
 
   std::string const convertedPath = Util::convertPath(dirPath);

--- a/config/Location.cpp
+++ b/config/Location.cpp
@@ -127,7 +127,7 @@ void Location::setMaxBodySize(int size) {
 // - Location 블럭에 특정 상태코드에 대한 error page 경로 추가
 // - 이미 있는 상태코드를 다시 추가할 경우 예외 발생
 void Location::addErrorPage(int statusCode, std::string const& path) {
-  if (statusCode < 0 or statusCode / 100 != 4 or statusCode / 100 != 5) {
+  if (statusCode < 0 or (statusCode / 100 != 4 and statusCode / 100 != 5)) {
     throw std::runtime_error("[] Location: addErrorPage - invalid statusCode");
   }
 

--- a/config/Location.cpp
+++ b/config/Location.cpp
@@ -127,13 +127,17 @@ void Location::setMaxBodySize(int size) {
 // - Location 블럭에 특정 상태코드에 대한 error page 경로 추가
 // - 이미 있는 상태코드를 다시 추가할 경우 예외 발생
 void Location::addErrorPage(int statusCode, std::string const& path) {
-  if (_errorPages.find(statusCode) != _errorPages.end()) {
-    throw std::runtime_error(
-        "[1101] Location: addErrorPage - duplicate status code");
+  if (statusCode < 0 or statusCode / 100 != 4 or statusCode / 100 != 5) {
+    throw std::runtime_error("[] Location: addErrorPage - invalid statusCode");
   }
 
   if (Util::isValidPath(path) == false) {
     throw std::runtime_error("[] Location: addErrorPage - invalid path");
+  }
+
+  if (_errorPages.find(statusCode) != _errorPages.end()) {
+    throw std::runtime_error(
+        "[1101] Location: addErrorPage - duplicate status code");
   }
 
   std::string const convertedPath = convertPath(path);
@@ -182,6 +186,10 @@ void Location::setRedirectUri(std::string const& path) {
 // CGI extension 설정
 // - 한 번이라도 메서드가 호출된 경우 cgi를 가지고 있다고 판단
 void Location::setCgiExtension(std::string const& extension) {
+  if (extension.size() == 0 or extension.front() != '.') {
+    throw std::runtime_error(
+        "[] Location: setCgiExtension - invalid extension");
+  }
   _cgiExtension = extension;
   _cgiFlag = true;
 }

--- a/config/Location.cpp
+++ b/config/Location.cpp
@@ -46,7 +46,7 @@ Location& Location::operator=(Location const& location) {
     this->_redirectUri = location._redirectUri;
 
     this->_cgiFlag = location._cgiFlag;
-    this->_cgiExtention = location._cgiExtention;
+    this->_cgiExtension = location._cgiExtension;
     this->_cgiPath = location._cgiPath;
     this->_uploadPath = location._uploadPath;
 
@@ -88,7 +88,7 @@ void Location::printConfiguration() {
 
   std::cout << "CGI flag: " << (_cgiFlag ? "on" : "off") << std::endl;
   if (_cgiFlag) {
-    std::cout << "CGI extension: " << _cgiExtention << std::endl;
+    std::cout << "CGI extension: " << _cgiExtension << std::endl;
     std::cout << "CGI path: " << _cgiPath << std::endl;
     std::cout << "upload path: " << _uploadPath << std::endl;
   }
@@ -179,10 +179,10 @@ void Location::setRedirectUri(std::string const& path) {
   _redirectUri = convertPath(path);
 }
 
-// CGI extention 설정
+// CGI extension 설정
 // - 한 번이라도 메서드가 호출된 경우 cgi를 가지고 있다고 판단
-void Location::setCgiExtention(std::string const& extention) {
-  _cgiExtention = extention;
+void Location::setCgiExtension(std::string const& extension) {
+  _cgiExtension = extension;
   _cgiFlag = true;
 }
 
@@ -272,13 +272,13 @@ std::string const& Location::getRedirectUri(void) const {
 // CGI 정보를 가지고 있는지 여부 반환
 bool Location::hasCgiInfo(void) const { return _cgiFlag; }
 
-// CGI extention 반환
+// CGI extension 반환
 // - CGI 정보가 설정되어 있지 않은데 호출된 경우 예외 발생
-std::string const& Location::getCgiExtention(void) const {
+std::string const& Location::getCgiExtension(void) const {
   if (_cgiFlag == false) {
-    throw std::runtime_error("[1105] Location: getCgiExtention - no cgi info");
+    throw std::runtime_error("[1105] Location: getCgiExtension - no cgi info");
   }
-  return _cgiExtention;
+  return _cgiExtension;
 }
 
 // CGI 경로 반환

--- a/config/Location.hpp
+++ b/config/Location.hpp
@@ -27,7 +27,7 @@ class Location {
   std::string _redirectUri;
 
   bool _cgiFlag;
-  std::string _cgiExtention;
+  std::string _cgiExtension;
   std::string _cgiPath;
   std::string _uploadPath;
 
@@ -55,7 +55,7 @@ class Location {
   void addAllowMethod(std::string methodString);
   void setAutoIndex(std::string const&);
   void setRedirectUri(std::string const& path);
-  void setCgiExtention(std::string const& extention);
+  void setCgiExtension(std::string const& extension);
   void setCgiPath(std::string const& cgiPath);
   void setUploadDir(std::string const& dirPath);
 
@@ -72,7 +72,7 @@ class Location {
   bool isRedirectBlock(void) const;
   std::string const& getRedirectUri(void) const;
   bool hasCgiInfo(void) const;
-  std::string const& getCgiExtention(void) const;
+  std::string const& getCgiExtension(void) const;
   std::string const& getCgiPath(void) const;
   std::string const& getUploadDirPath(void) const;
 

--- a/config/Location.hpp
+++ b/config/Location.hpp
@@ -80,7 +80,6 @@ class Location {
 
  private:
   std::string getFullPath(std::string const& path);
-  std::string convertPath(std::string const& path);
 };
 
 #endif

--- a/config/Location.hpp
+++ b/config/Location.hpp
@@ -52,8 +52,8 @@ class Location {
   void setIndexFile(std::string const& indexFile);
   void setMaxBodySize(int size);
   void addErrorPage(int statusNumber, std::string const& path);
-  void addAllowMethod(EHttpMethod method);
-  void setAutoIndex(bool setting);
+  void addAllowMethod(std::string methodString);
+  void setAutoIndex(std::string const&);
   void setRedirectUri(std::string const& path);
   void setCgiExtention(std::string const& extention);
   void setCgiPath(std::string const& cgiPath);

--- a/config/Location.hpp
+++ b/config/Location.hpp
@@ -79,6 +79,8 @@ class Location {
   bool isRequiredValuesSet(void) const;
 
  private:
+  std::string getFullPath(std::string const& path);
+  std::string convertPath(std::string const& path);
 };
 
 #endif

--- a/config/Server.cpp
+++ b/config/Server.cpp
@@ -7,11 +7,7 @@
 Server::Server(void) : _port(-1), _isIncludeRootBlock(false) {}
 
 Server::Server(std::string hostIp, int port)
-    : _hostIp(hostIp),
-      _port(port),
-      _isIncludeRootBlock(false){
-          // TODO: invalid한 포트 번호 검증 추가
-      };
+    : _hostIp(hostIp), _port(port), _isIncludeRootBlock(false) {}
 
 Server::Server(Server const& server) { *this = server; }
 
@@ -39,7 +35,12 @@ int Server::getPort(void) const { return _port; }
 
 // Public Method - setter
 
-void Server::setHostIp(std::string const& hostIp) { _hostIp = hostIp; }
+void Server::setHostIp(std::string const& hostIp) {
+  if (isValidIpFormat(hostIp) == false) {
+    throw std::runtime_error("[] Server: setHostIp - invalid ip format");
+  }
+  _hostIp = hostIp;
+}
 
 void Server::setPort(int port) { _port = port; }
 
@@ -107,4 +108,30 @@ bool Server::hasServerName(std::string const& host) {
 
 bool Server::isRequiredValuesSet(void) const {
   return (_hostIp.size() != 0 and _port != -1 and _isIncludeRootBlock);
+}
+
+// Private method
+bool Server::isValidIpFormat(std::string const& ip) {
+  std::istringstream ss(ip);
+  std::string token;
+  int segmentCount = 0;
+
+  while (std::getline(ss, token, '.')) {
+    segmentCount++;
+    if (segmentCount > 4 || token.empty() || token.length() > 3) {
+      return false;
+    }
+
+    for (size_t j = 0; j < token.length(); j++) {
+      if (!isdigit(token[j])) {
+        return false;
+      }
+    }
+
+    int num = Util::stoi(token);
+    if (num < 0 || num > 255) {
+      return false;
+    }
+  }
+  return ss.eof() && segmentCount == 4 && ip[ip.length() - 1] != '.';
 }

--- a/config/Server.cpp
+++ b/config/Server.cpp
@@ -51,11 +51,11 @@ int Server::getPort(void) const { return _port; }
 // - IP 형식이 잘못된 경우 예외 발생
 void Server::setHostIp(std::string const& hostIp) {
   if (_isHostIpSet) {
-    throw std::runtime_error("[] Server: setHostIp - host ip already set");
+    throw std::runtime_error("[1002] Server: setHostIp - host ip already set");
   }
 
   if (isValidIpFormat(hostIp) == false) {
-    throw std::runtime_error("[] Server: setHostIp - invalid ip format");
+    throw std::runtime_error("[1003] Server: setHostIp - invalid ip format");
   }
 
   _hostIp = hostIp;
@@ -67,11 +67,11 @@ void Server::setHostIp(std::string const& hostIp) {
 // - 포트 번호가 잘못된 경우 예외 발생
 void Server::setPort(std::string const& port) {
   if (_isPortSet) {
-    throw std::runtime_error("[] Server: setPort - port already set");
+    throw std::runtime_error("[1004] Server: setPort - port already set");
   }
 
   if (isValidPort(port) == false) {
-    throw std::runtime_error("[] Server: setPort - invalid port");
+    throw std::runtime_error("[1005] Server: setPort - invalid port");
   }
 
   _port = Util::stoi(port);
@@ -89,7 +89,8 @@ void Server::addServerName(std::string const& serverName) {
     if (Util::isUnreserved(ch) or Util::isSubDelims(ch)) continue;
     if (Util::isPctEncoded(serverName.substr(i, 3))) continue;
 
-    throw std::runtime_error("[] Server: addServerName - invalid server_name");
+    throw std::runtime_error(
+        "[1006] Server: addServerName - invalid server_name");
   }
 
   if (_serverNames.find(serverName) != _serverNames.end()) {

--- a/config/Server.cpp
+++ b/config/Server.cpp
@@ -167,7 +167,7 @@ bool Server::isValidIpFormat(std::string const& ip) {
 
   while (std::getline(ss, token, '.')) {
     segmentCount++;
-    if (segmentCount > 4 || token.empty() || token.length() > 3) {
+    if (segmentCount > 4 or token.empty() or token.length() > 3) {
       return false;
     }
 
@@ -178,16 +178,16 @@ bool Server::isValidIpFormat(std::string const& ip) {
     }
 
     int num = Util::stoi(token);
-    if (num < 0 || num > 255) {
+    if (num < 0 or num > 255) {
       return false;
     }
   }
-  return ss.eof() && segmentCount == 4 && ip[ip.length() - 1] != '.';
+  return ss.eof() and segmentCount == 4 and ip[ip.length() - 1] != '.';
 }
 
 // 포트 번호가 올바른지 여부 반환
 bool Server::isValidPort(const std::string& port) {
-  if (port.empty() || port.length() > 5) {
+  if (port.empty() or port.length() > 5) {
     return false;
   }
 
@@ -198,7 +198,7 @@ bool Server::isValidPort(const std::string& port) {
   }
 
   int portNum = Util::stoi(port);
-  if (portNum < 0 || portNum > 65535) {
+  if (portNum < 0 or portNum > 65535) {
     return false;
   }
 

--- a/config/Server.cpp
+++ b/config/Server.cpp
@@ -82,10 +82,8 @@ void Server::setPort(std::string const& port) {
 // - 올바르지 않은 문자를 가진 server name이 들어온 경우 예외 발생
 // - 이미 있는 server name이 들어올 경우 예외 발생
 void Server::addServerName(std::string const& serverName) {
-  std::string const& others = "/:@";
   for (size_t i = 0; i < serverName.size(); i++) {
     char ch = serverName[i];
-    if (others.find(ch) != std::string::npos) continue;
     if (Util::isUnreserved(ch) or Util::isSubDelims(ch)) continue;
     if (Util::isPctEncoded(serverName.substr(i, 3))) continue;
 

--- a/config/Server.cpp
+++ b/config/Server.cpp
@@ -4,10 +4,18 @@
 
 // Constructor & Destructor
 
-Server::Server(void) : _port(-1), _isIncludeRootBlock(false) {}
+Server::Server(void)
+    : _port(-1),
+      _isHostIpSet(false),
+      _isPortSet(false),
+      _isIncludeRootBlock(false) {}
 
 Server::Server(std::string hostIp, int port)
-    : _hostIp(hostIp), _port(port), _isIncludeRootBlock(false) {}
+    : _hostIp(hostIp),
+      _port(port),
+      _isHostIpSet(false),
+      _isPortSet(false),
+      _isIncludeRootBlock(false) {}
 
 Server::Server(Server const& server) { *this = server; }
 
@@ -22,6 +30,9 @@ Server& Server::operator=(Server const& server) {
 
     this->_serverNames = server._serverNames;
     this->_locationBlocks = server._locationBlocks;
+
+    this->_isHostIpSet = server._isHostIpSet;
+    this->_isPortSet = server._isPortSet;
     this->_isIncludeRootBlock = server._isIncludeRootBlock;
   }
   return *this;
@@ -36,21 +47,35 @@ int Server::getPort(void) const { return _port; }
 // Public Method - setter
 
 // Host IP를 설정
+// - IP가 설정되어 있는데 다시 호출한 경우 예외 발생
 // - IP 형식이 잘못된 경우 예외 발생
 void Server::setHostIp(std::string const& hostIp) {
+  if (_isHostIpSet) {
+    throw std::runtime_error("[] Server: setHostIp - host ip already set");
+  }
+
   if (isValidIpFormat(hostIp) == false) {
     throw std::runtime_error("[] Server: setHostIp - invalid ip format");
   }
+
   _hostIp = hostIp;
+  _isHostIpSet = true;
 }
 
 // Port를 설정
+// - 이미 포트 번호가 설정되어 있는데 다시 호출한 경우 예외 발생
 // - 포트 번호가 잘못된 경우 예외 발생
 void Server::setPort(std::string const& port) {
+  if (_isPortSet) {
+    throw std::runtime_error("[] Server: setPort - port already set");
+  }
+
   if (isValidPort(port) == false) {
     throw std::runtime_error("[] Server: setPort - invalid port");
   }
+
   _port = Util::stoi(port);
+  _isPortSet = true;
 }
 
 // server name을 추가

--- a/config/Server.cpp
+++ b/config/Server.cpp
@@ -35,6 +35,8 @@ int Server::getPort(void) const { return _port; }
 
 // Public Method - setter
 
+// Host IP를 설정
+// - IP 형식이 잘못된 경우 예외 발생
 void Server::setHostIp(std::string const& hostIp) {
   if (isValidIpFormat(hostIp) == false) {
     throw std::runtime_error("[] Server: setHostIp - invalid ip format");
@@ -42,6 +44,8 @@ void Server::setHostIp(std::string const& hostIp) {
   _hostIp = hostIp;
 }
 
+// Port를 설정
+// - 포트 번호가 잘못된 경우 예외 발생
 void Server::setPort(std::string const& port) {
   if (isValidPort(port) == false) {
     throw std::runtime_error("[] Server: setPort - invalid port");

--- a/config/Server.cpp
+++ b/config/Server.cpp
@@ -42,7 +42,12 @@ void Server::setHostIp(std::string const& hostIp) {
   _hostIp = hostIp;
 }
 
-void Server::setPort(int port) { _port = port; }
+void Server::setPort(std::string const& port) {
+  if (isValidPort(port) == false) {
+    throw std::runtime_error("[] Server: setHostIp - invalid port");
+  }
+  _port = Util::stoi(port);
+}
 
 // - server name을 추가
 // - 이미 있는 server name이 들어올 경우 예외 발생
@@ -111,6 +116,8 @@ bool Server::isRequiredValuesSet(void) const {
 }
 
 // Private method
+
+// IP 형식이 올바른지 여부 반환
 bool Server::isValidIpFormat(std::string const& ip) {
   std::istringstream ss(ip);
   std::string token;
@@ -134,4 +141,29 @@ bool Server::isValidIpFormat(std::string const& ip) {
     }
   }
   return ss.eof() && segmentCount == 4 && ip[ip.length() - 1] != '.';
+}
+
+// 포트 번호가 올바른지 여부 반환
+bool Server::isValidPort(const std::string& port) {
+  if (port.empty() || port.length() > 5) {
+    return false;
+  }
+
+  for (size_t i = 0; i < port.length(); i++) {
+    if (!isdigit(port[i])) {
+      return false;
+    }
+  }
+
+  int portNum = Util::stoi(port);
+  if (portNum < 0 || portNum > 65535) {
+    return false;
+  }
+
+  // well known port
+  if (portNum <= 1023) {
+    return false;
+  }
+
+  return true;
 }

--- a/config/Server.cpp
+++ b/config/Server.cpp
@@ -44,18 +44,30 @@ void Server::setHostIp(std::string const& hostIp) {
 
 void Server::setPort(std::string const& port) {
   if (isValidPort(port) == false) {
-    throw std::runtime_error("[] Server: setHostIp - invalid port");
+    throw std::runtime_error("[] Server: setPort - invalid port");
   }
   _port = Util::stoi(port);
 }
 
-// - server name을 추가
+// server name을 추가
+// - 올바르지 않은 문자를 가진 server name이 들어온 경우 예외 발생
 // - 이미 있는 server name이 들어올 경우 예외 발생
 void Server::addServerName(std::string const& serverName) {
+  std::string const& others = "/:@";
+  for (size_t i = 0; i < serverName.size(); i++) {
+    char ch = serverName[i];
+    if (others.find(ch) != std::string::npos) continue;
+    if (Util::isUnreserved(ch) or Util::isSubDelims(ch)) continue;
+    if (Util::isPctEncoded(serverName.substr(i, 3))) continue;
+
+    throw std::runtime_error("[] Server: addServerName - invalid server_name");
+  }
+
   if (_serverNames.find(serverName) != _serverNames.end()) {
     throw std::runtime_error(
         "[1000] Server: addServerName - duplicate server_name");
   }
+
   _serverNames.insert(serverName);
 }
 

--- a/config/Server.hpp
+++ b/config/Server.hpp
@@ -19,6 +19,8 @@ class Server {
   std::set<std::string> _serverNames;
   std::map<std::string, Location> _locationBlocks;
 
+  bool _isHostIpSet;
+  bool _isPortSet;
   bool _isIncludeRootBlock;
 
  public:

--- a/config/Server.hpp
+++ b/config/Server.hpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <map>
 #include <set>
+#include <sstream>
 #include <string>
 
 #include "Location.hpp"
@@ -45,6 +46,8 @@ class Server {
 
  private:
   typedef std::map<std::string, Location> LocationMap;
+
+  bool isValidIpFormat(std::string const& ip);
 };
 
 #endif

--- a/config/Server.hpp
+++ b/config/Server.hpp
@@ -33,7 +33,7 @@ class Server {
   int getPort(void) const;
 
   void setHostIp(std::string const& hostIp);
-  void setPort(int port);
+  void setPort(std::string const& port);
 
   void addServerName(std::string const& serverName);
   void addLocationBlock(Location const& locationBlock);
@@ -48,6 +48,7 @@ class Server {
   typedef std::map<std::string, Location> LocationMap;
 
   bool isValidIpFormat(std::string const& ip);
+  bool isValidPort(const std::string& port);
 };
 
 #endif

--- a/core/Socket.hpp
+++ b/core/Socket.hpp
@@ -1,6 +1,7 @@
 #ifndef __SOCKET_HPP__
 #define __SOCKET_HPP__
 
+#include <cstdio>
 #include <string>
 
 // 소켓 api를 제공하는 정적 클래스

--- a/http/BuilderSelector.cpp
+++ b/http/BuilderSelector.cpp
@@ -49,7 +49,7 @@ bool BuilderSelector::isCgiBuilderSelected(Request const& request,
   if (request.getMethod() == HTTP_POST) return true;
 
   if (location.hasCgiInfo() and
-      Config::findFileExtension(fullPath) == location.getCgiExtention())
+      Config::findFileExtension(fullPath) == location.getCgiExtension())
     return true;
 
   return false;

--- a/http/BuilderSelector.cpp
+++ b/http/BuilderSelector.cpp
@@ -12,7 +12,8 @@ AResponseBuilder* BuilderSelector::getMatchingBuilder(Request const& request) {
   if (BuilderSelector::isAutoindexBuilderSelected(request))
     return new AutoindexBuilder(request);
 
-  if (fullPath.back() == '/') fullPath = request.generateIndexPath();
+  if (fullPath[fullPath.size() - 1] == '/')
+    fullPath = request.generateIndexPath();
 
   if (BuilderSelector::isCgiBuilderSelected(request, fullPath))
     return new CgiBuilder(request);
@@ -31,7 +32,7 @@ AResponseBuilder* BuilderSelector::getMatchingBuilder(Request const& request) {
 bool BuilderSelector::isAutoindexBuilderSelected(Request const& request) {
   std::string fullPath = request.getFullPath();
 
-  if (fullPath.back() != '/') return false;
+  if (fullPath[fullPath.size() - 1] != '/') return false;
 
   if (request.getMethod() != HTTP_GET) return true;
 

--- a/http/CgiBuilder.cpp
+++ b/http/CgiBuilder.cpp
@@ -96,7 +96,7 @@ void CgiBuilder::checkPathInfo(void) {
   Request const& request = getRequest();
 
   // 디렉토리로 끝나는 경우 index 정보를 붙여 확인
-  if (request.getFullPath().back() == '/') {
+  if (request.getFullPath()[request.getFullPath().size() - 1] == '/') {
     _cgiPathInfo = request.generateIndexPath();
   } else {
     _cgiPathInfo = request.getFullPath();

--- a/http/CgiBuilder.cpp
+++ b/http/CgiBuilder.cpp
@@ -447,7 +447,7 @@ char** CgiBuilder::makeEnv(void) {
     std::string key = it->first;
 
     // "x-"로 시작하는지 확인
-    if (key.length() >= 2 && key.substr(0, 2) == "x-") {
+    if (key.length() >= 2 and key.substr(0, 2) == "x-") {
       // "HTTP_" 접두사 추가
       key = "HTTP_" + key;
 

--- a/http/CgiBuilder.cpp
+++ b/http/CgiBuilder.cpp
@@ -176,11 +176,17 @@ void CgiBuilder::childProcess(int* const p_to_c, int* const c_to_p) {
       throw std::runtime_error("CGI Access Fail");
     }
 
+    // execve에 사용할 argv 배열 생성
+    char* argv[2];
+    argv[0] = const_cast<char*>(cgiPath.c_str());
+    argv[1] = NULL;
+
     // cgi에 인자 및 환경변수 전송
-    if (execve(cgiPath.c_str(), NULL, envp) < 0) {
+    if (execve(cgiPath.c_str(), argv, envp) < 0) {
       freeEnvArray(envp);
       throw std::runtime_error("CGI Execve Fail");
     }
+
   } catch (std::exception const& e) {
     std::cout << "Status: 500 " << e.what() << "\r\n";
     std::cout << "Content-Type: text/html\r\n\r\n";

--- a/http/CgiBuilder.cpp
+++ b/http/CgiBuilder.cpp
@@ -91,7 +91,7 @@ void CgiBuilder::close(void) {
  */
 
 // CGI Builder에게 전달되는 path 정보가 올바른지 검사
-// - CGI extention으로 끝나지 않는 경로인 경우 403 예외 발생
+// - CGI extension으로 끝나지 않는 경로인 경우 403 예외 발생
 void CgiBuilder::checkPathInfo(void) {
   Request const& request = getRequest();
 
@@ -102,11 +102,11 @@ void CgiBuilder::checkPathInfo(void) {
     _cgiPathInfo = request.getFullPath();
   }
 
-  // CGI extention 정보 확인
-  std::string const& extention = request.getLocation().getCgiExtention();
-  if (endsWith(_cgiPathInfo, extention) == false) {
+  // CGI extension 정보 확인
+  std::string const& extension = request.getLocation().getCgiExtension();
+  if (endsWith(_cgiPathInfo, extension) == false) {
     throw StatusException(
-        HTTP_FORBIDDEN, "[5401] CgiBuilder: checkPathInfo - invalid extention");
+        HTTP_FORBIDDEN, "[5401] CgiBuilder: checkPathInfo - invalid extension");
   }
 }
 

--- a/http/CgiBuilder.hpp
+++ b/http/CgiBuilder.hpp
@@ -4,6 +4,7 @@
 #include <signal.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cctype>
 #include <cstring>
 #include <iostream>
@@ -51,8 +52,7 @@ class CgiBuilder : public AResponseBuilder {
 
   virtual void buildResponseContent(std::string const& cgiResponse);
   void trim(std::string& str);
-  bool endsWith(const std::string& fullString,
-                          const std::string& ending);
+  bool endsWith(const std::string& fullString, const std::string& ending);
 
   char** makeEnv(void);
   char** createEnvArray(std::map<std::string, std::string> const& env);

--- a/http/ErrorBuilder.cpp
+++ b/http/ErrorBuilder.cpp
@@ -129,13 +129,10 @@ int ErrorBuilder::readStatusCodeFile(Location const& location) {
 // 상태코드에 해당하는 에러 파일 열기
 // - 파일이 없거나 open에 실패한 경우 예외 발생
 void ErrorBuilder::openStatusCodeFile(Location const& location) {
-  // 파일 경로 제작
-  std::string const& root = location.getRootPath();
   std::string const& path = location.getErrorPagePath(_statusCode);
-  std::string const& fullPath = root + path;
 
   // 파일 접근 권한 확인
-  if (access(fullPath.c_str(), F_OK | R_OK) == -1) {
+  if (access(path.c_str(), F_OK | R_OK) == -1) {
     throw StatusException(
         HTTP_INTERNAL_SERVER_ERROR,
         "[5101] ErrorBuilder: openStatusCodeFile - file permissions denied");
@@ -144,7 +141,7 @@ void ErrorBuilder::openStatusCodeFile(Location const& location) {
   // 파일 크기 측정
   struct stat statbuf;
 
-  if (stat(fullPath.c_str(), &statbuf) == -1) {
+  if (stat(path.c_str(), &statbuf) == -1) {
     throw std::runtime_error(
         "[5102] ErrorBuilder: openStatusCodeFile - stat failed");
   }
@@ -152,7 +149,7 @@ void ErrorBuilder::openStatusCodeFile(Location const& location) {
   _fileSize = statbuf.st_size;
 
   // 파일 열기
-  _fileFd = open(fullPath.c_str(), O_RDONLY);
+  _fileFd = open(path.c_str(), O_RDONLY);
   if (_fileFd < 0) {
     throw std::runtime_error(
         "[5103] ErrorBuilder: openStatusCodeFile - open failed");

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -128,7 +128,7 @@ std::string const Request::generateIndexPath(void) const {
   std::string const& indexFile = location.getIndexFile();
   std::string fullPath = getFullPath();
 
-  if (indexFile.front() == '/') fullPath.pop_back();
+  if (indexFile[0] == '/') fullPath.substr(0, fullPath.size() - 1);
   fullPath += indexFile;
 
   return fullPath;
@@ -195,9 +195,11 @@ void Request::storeFullPath(void) {
   std::string locationUri = location.getUri();
 
   // path의 맨 처음이 무조건 /로 시작해 /를 제거
-  if (projectPath.back() == '/') projectPath.pop_back();
-  if (root.back() == '/') root.pop_back();
-  if (locationUri.back() == '/') locationUri.pop_back();
+  if (projectPath[projectPath.size() - 1] == '/')
+    projectPath.substr(0, projectPath.size() - 1);
+  if (root[root.size() - 1] == '/') root.substr(0, root.size() - 1);
+  if (locationUri[locationUri.size() - 1] == '/')
+    locationUri.substr(0, locationUri.size() - 1);
 
   size_t pos = _path.find(locationUri);
 

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -128,7 +128,7 @@ std::string const Request::generateIndexPath(void) const {
   std::string const& indexFile = location.getIndexFile();
   std::string fullPath = getFullPath();
 
-  if (indexFile[0] == '/') fullPath.substr(0, fullPath.size() - 1);
+  if (indexFile[0] == '/') fullPath = fullPath.substr(0, fullPath.size() - 1);
   fullPath += indexFile;
 
   return fullPath;
@@ -195,11 +195,15 @@ void Request::storeFullPath(void) {
   std::string locationUri = location.getUri();
 
   // path의 맨 처음이 무조건 /로 시작해 /를 제거
-  if (projectPath[projectPath.size() - 1] == '/')
-    projectPath.substr(0, projectPath.size() - 1);
-  if (root[root.size() - 1] == '/') root.substr(0, root.size() - 1);
-  if (locationUri[locationUri.size() - 1] == '/')
-    locationUri.substr(0, locationUri.size() - 1);
+  if (projectPath[projectPath.size() - 1] == '/') {
+    projectPath = projectPath.substr(0, projectPath.size() - 1);
+  }
+  if (root[root.size() - 1] == '/') {
+    root = root.substr(0, root.size() - 1);
+  }
+  if (locationUri[locationUri.size() - 1] == '/') {
+    locationUri = locationUri.substr(0, locationUri.size() - 1);
+  }
 
   size_t pos = _path.find(locationUri);
 

--- a/http/Request.cpp
+++ b/http/Request.cpp
@@ -162,7 +162,7 @@ void Request::storeRequestTarget(std::string const& requestTarget) {
         "[2104] Request: storeRequestTarget - request Target is invalid");
   }
 
-  setPath(Util::pctDecode(path));
+  setPath(Util::convertPath(path));
   setQuery(Util::pctDecode(query));
 }
 

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -538,12 +538,12 @@ void RequestParser::removeCRLF(std::vector<octet_t>& vec) {
 // string의 선행, 후행 공백 제거
 std::string RequestParser::trim(std::string const& str) {
   std::string::const_iterator it = str.begin();
-  while (it != str.end() && isWhitespace(*it)) {
+  while (it != str.end() and isWhitespace(*it)) {
     ++it;
   }
 
   std::string::const_reverse_iterator rit = str.rbegin();
-  while (rit.base() != it && isWhitespace(*rit)) {
+  while (rit.base() != it and isWhitespace(*rit)) {
     ++rit;
   }
 

--- a/http/RequestParser.cpp
+++ b/http/RequestParser.cpp
@@ -380,7 +380,7 @@ std::vector<std::string> RequestParser::processHeaderField() {
 
   int const fieldNameIndex = 0, fieldValueIndex = 1;
   if (result[fieldNameIndex].size() < 1 or
-      isWhitespace(result[fieldNameIndex].back())) {
+      isWhitespace(result[fieldNameIndex][result[fieldNameIndex].size() - 1])) {
     throw StatusException(
         HTTP_BAD_REQUEST,
         "[2201] RequestParser: processHeaderField - No whitespace is "

--- a/http/Response.cpp
+++ b/http/Response.cpp
@@ -33,8 +33,7 @@ Response& Response::operator=(Response const& response) {
 
 // 디버깅용 Response 정보 출력 함수
 void Response::print() const {
-  // std::cout << "Response Content: " << _responseContent << std::endl;
-  std::cout << "Start Index: " << _startIndex << std::endl;
+  // std::cout << "Start Index: " << _startIndex << std::endl;
   std::cout << "HTTP Version: " << _httpVersion << std::endl;
   std::cout << "StatusCode: " << _statusCode << std::endl;
 

--- a/http/StaticFileBuilder.cpp
+++ b/http/StaticFileBuilder.cpp
@@ -75,7 +75,7 @@ void StaticFileBuilder::openStaticFile(void) {
   std::string fullPath = request.getFullPath();
 
   // 파일이 디렉토리라면 index 파일 붙이기
-  if (fullPath.back() == '/') {
+  if (fullPath[fullPath.size() - 1] == '/') {
     fullPath = request.generateIndexPath();
   }
 
@@ -146,7 +146,7 @@ void StaticFileBuilder::buildResponseContent(std::string const& body) {
   Request const& request = getRequest();
   std::string fullPath = request.getFullPath();
 
-  if (fullPath.back() == '/') {
+  if (fullPath[fullPath.size() - 1] == '/') {
     fullPath = request.generateIndexPath();
   }
 

--- a/server/Connection.cpp
+++ b/server/Connection.cpp
@@ -107,6 +107,10 @@ void Connection::parseRequest(octet_t const* buffer, ssize_t bytesRead) {
   if (_requestParser.getParsingStatus() == DONE) {
     setStatus(TO_SEND);
 
+    std::cout << "------------------------------------\n"
+              << "[ Server: request received ]\n"
+              << "------------------------------------\n";
+
     // debug
     Request const& request = _requestParser.getRequest();
     request.print();
@@ -189,9 +193,10 @@ void Connection::sendResponse(void) {
   updateLastCallTime();
 
   if (isDone) {
-    std::cout << "[ Server: response sent ]\n"
-              << "-------------\n";
-    // << responseContent << "\n-------------" << std::endl;
+    std::cout << "------------------------------------\n"
+              << "[ Server: response sent ]\n"
+              << "------------------------------------\n";
+
     response.print();
 
     _responseBuilder->isConnectionClose() ? setStatus(CLOSE)

--- a/utils/Util.cpp
+++ b/utils/Util.cpp
@@ -49,7 +49,7 @@ std::string const Util::removeDotSegments(std::string const& path) {
       if (pos != std::string::npos) {
         outputBuffer.erase(pos);
       }
-    } else if (!segment.empty() and segment != "/") {
+    } else if (!segment.empty()) {
       outputBuffer += segment;
     }
 

--- a/utils/Util.cpp
+++ b/utils/Util.cpp
@@ -146,7 +146,7 @@ EHttpMethod Util::matchEHttpMethod(std::string method) {
   if (method == "GET") return HTTP_GET;
   if (method == "POST") return HTTP_POST;
   if (method == "DELETE") return HTTP_DELETE;
-  throw std::runtime_error("[] Util: matchEHttpMethod - match failed");
+  throw std::runtime_error("[6103] Util: matchEHttpMethod - match failed");
 }
 
 std::string Util::convertPath(std::string const& path) {

--- a/utils/Util.cpp
+++ b/utils/Util.cpp
@@ -42,14 +42,14 @@ std::string const Util::removeDotSegments(std::string const& path) {
                               ? inputBuffer.substr(0, segmentEnd)
                               : inputBuffer;
 
-    if (segment == "/." || segment == ".") {
+    if (segment == "/." or segment == ".") {
       // pass
-    } else if (segment == "/.." || segment == "..") {
+    } else if (segment == "/.." or segment == "..") {
       std::size_t pos = outputBuffer.find_last_of('/');
       if (pos != std::string::npos) {
         outputBuffer.erase(pos);
       }
-    } else if (!segment.empty() && segment != "/") {
+    } else if (!segment.empty() and segment != "/") {
       outputBuffer += segment;
     }
 

--- a/utils/Util.cpp
+++ b/utils/Util.cpp
@@ -18,6 +18,12 @@ int Util::stoi(std::string const& str) {
   return n;
 }
 
+// string을 모두 대문자로 변경
+void Util::toUpperCase(std::string& str) {
+  for (std::string::iterator it = str.begin(); it != str.end(); ++it)
+    *it = std::toupper(static_cast<unsigned char>(*it));
+}
+
 // string을 모두 소문자로 변경
 void Util::toLowerCase(std::string& str) {
   for (std::string::iterator it = str.begin(); it != str.end(); ++it)
@@ -132,4 +138,13 @@ bool Util::isValidQuery(std::string const& query) {
     return false;
   }
   return true;
+}
+
+// method가 매칭되는 enum EHttpMethod를 반환
+// - 매칭되는 EHttpMethod가 없는 경우 예외 발생
+EHttpMethod Util::matchEHttpMethod(std::string method) {
+  if (method == "GET") return HTTP_GET;
+  if (method == "POST") return HTTP_POST;
+  if (method == "DELETE") return HTTP_DELETE;
+  throw std::runtime_error("[] Util: matchEHttpMethod - match failed");
 }

--- a/utils/Util.cpp
+++ b/utils/Util.cpp
@@ -94,7 +94,7 @@ bool Util::isHex(char ch) {
 }
 
 bool Util::isPctEncoded(std::string const& str) {
-  if (str.front() != '%' or str.size() != 3) return false;
+  if (str[0] != '%' or str.size() != 3) return false;
   if (Util::isHex(str[1]) and Util::isHex(str[2])) return true;
   return false;
 }
@@ -112,7 +112,7 @@ bool Util::isSubDelims(char ch) {
 }
 
 bool Util::isValidPath(std::string const& path) {
-  if (path.size() < 1 or path.front() != '/') return false;
+  if (path.size() < 1 or path[0] != '/') return false;
 
   std::string const& others = "/:@";
   for (size_t i = 0; i < path.size(); i++) {

--- a/utils/Util.cpp
+++ b/utils/Util.cpp
@@ -148,3 +148,7 @@ EHttpMethod Util::matchEHttpMethod(std::string method) {
   if (method == "DELETE") return HTTP_DELETE;
   throw std::runtime_error("[] Util: matchEHttpMethod - match failed");
 }
+
+std::string Util::convertPath(std::string const& path) {
+  return Util::removeDotSegments(Util::pctDecode(path));
+}

--- a/utils/Util.hpp
+++ b/utils/Util.hpp
@@ -25,6 +25,7 @@ class Util {
   static bool isValidPath(std::string const& path);
   static bool isValidQuery(std::string const& query);
   static EHttpMethod matchEHttpMethod(std::string method);
+  static std::string convertPath(std::string const& path);
 
  private:
   Util(void);

--- a/utils/Util.hpp
+++ b/utils/Util.hpp
@@ -7,10 +7,13 @@
 #include <stdexcept>
 #include <string>
 
+#include "Enum.hpp"
+
 class Util {
  public:
   static std::string const itos(int n);
   static int stoi(std::string const& str);
+  static void toUpperCase(std::string& str);
   static void toLowerCase(std::string& str);
   static std::string const removeDotSegments(std::string const& path);
   static bool isHex(char ch);
@@ -21,6 +24,7 @@ class Util {
   static std::string pctDecode(std::string const& str);
   static bool isValidPath(std::string const& path);
   static bool isValidQuery(std::string const& query);
+  static EHttpMethod matchEHttpMethod(std::string method);
 
  private:
   Util(void);


### PR DESCRIPTION
## project root path
- path 유효성 검사 추가

## Server 블록
> Assignee: @wonyangs

### IP 주소 형식 검사 추가

- [0-255].[0-255].[0-255].[0-255] 이 아닌 형식의 문자열을 받았을 경우 예외 처리

### 포트 값 검사 로직 추가

- ConfigParser가 포트를 문자열로 전달하도록 수정
- Server 클래스에 올바른 포트 번호인지 검사하는 로직 추가
  - 올바르지 않은 문자가 들어온 경우 예외
  - well known, 사용가능한 포트 범위가 아닌 경우 예외

### server_name 검사 로직 추가

- reg-name = *( unreserved / pct-encoded / sub-delims ) 형식을 지키지 않은 경우 발생

### 중복된 지시자 검사 로직 추가

- host ip와 port가 설정되어 있는지 여부를 저장하는 멤버 변수 추가
- ip와 port가 이미 설정된 상태에서 다시 호출될 경우 예외 발생

## location 블록
> Assignee: @mingxoxo 

### 중복된 지시자 검사 로직 추가
- error page를 제외하고 중복된 지시자가 들어오는 경우 예외

### path 유효성 검사 및 변환
- root, index, error_page uri, cgi path, cgi upload dir, redirect에 대해 적용
  - 추가로 request path에도 추가 
- path값 변환(pct-decoded, remove dot segments)
- error_page uri, cgi path, cgi upload dir를 저장할 때 project root path를 붙여서 저장
  - ErrorBuilder에서 파일 경로 부분 수정

### ConfigParser에서 이동
- 함수 자료형 변경
- allow_method: 허용하지 않는 메서드 들어왔는지 검사 
- autoindex - on, off만 허용

### 기타 지시자
- (이미 구현됨) client_max_body_size: int로 변환 실패, 허용하는 범위를 넘어섰는지
- error_page code
  - 모두 숫자인지 확인(stoi), 3자리 인지 확인, 4XX, 5XX 인 경우 확인
  - (이미 구현됨) 중복된 코드인지 확인
- cgi extension: . 으로 시작하는지 확인

### config 파일 수정
- config 파일을 파싱 조건에 맞게 수정
